### PR TITLE
Set builder image to jdk 11.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the jar
-FROM maven:latest AS maven
+FROM maven:3-jdk-11 AS maven
 
 COPY pom.xml /tmp/
 


### PR DESCRIPTION
Latest image refers to jdk 16 which isn't supported by Lombok.
It's better to use a fixed version number for docker images to prevent unintended version updates.