### PR TITLE
204 prevent swagger UI to load default playground by missing config url(pet store)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
 		<modelmapper.version>2.3.9</modelmapper.version>
 		<jackson.version>2.10.0.pr2</jackson.version>
 		<postgres.version>42.2.19</postgres.version>
-		<springdoc-ui.version>1.4.1</springdoc-ui.version>
-		<springdoc-security.version>1.4.1</springdoc-security.version>
+		<springdoc-ui.version>1.5.4</springdoc-ui.version>
+		<springdoc-security.version>1.5.4</springdoc-security.version>
 		<jsonld-java.version>0.13.0</jsonld-java.version>
 		<equalsverifier.version>3.5.5</equalsverifier.version>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,7 @@ spring.security.user.password=password
 ## OpenAPI
 springdoc.swagger-ui.path=/api/docs
 springdoc.swagger-ui.operationsSorter=alpha
+springdoc.swagger-ui.disable-swagger-default-url=true
 
 ## HTTP 2
 # server.http2.enabled=true


### PR DESCRIPTION
Updating swagger dependencies for sprincdoc-ui and springdoc-security and adding a property for the default url fixed the problem.