### PR TITLE
fix: remove encoding from optional path segment 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed missing IDS context in `/api/examples/policy`.
 - Disable autocommit on database transactions.
+- Remove encoding from optional path segment in `HttpService`.
 
 ### Changed
 - Increase IDS Framework version to 5.0.3.

--- a/src/main/java/io/dataspaceconnector/services/HttpService.java
+++ b/src/main/java/io/dataspaceconnector/services/HttpService.java
@@ -15,13 +15,6 @@
  */
 package io.dataspaceconnector.services;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-
 import io.dataspaceconnector.model.QueryInput;
 import io.dataspaceconnector.utils.ErrorMessages;
 import io.dataspaceconnector.utils.Utils;
@@ -34,6 +27,13 @@ import lombok.RequiredArgsConstructor;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class builds up http or httpS endpoint connections and sends GET requests.

--- a/src/main/java/io/dataspaceconnector/services/HttpService.java
+++ b/src/main/java/io/dataspaceconnector/services/HttpService.java
@@ -15,6 +15,13 @@
  */
 package io.dataspaceconnector.services;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
 import io.dataspaceconnector.model.QueryInput;
 import io.dataspaceconnector.utils.ErrorMessages;
 import io.dataspaceconnector.utils.Utils;
@@ -27,13 +34,6 @@ import lombok.RequiredArgsConstructor;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import org.springframework.stereotype.Service;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * This class builds up http or httpS endpoint connections and sends GET requests.
@@ -187,7 +187,7 @@ public class HttpService {
     private URL buildTargetUrl(final URL target, final String optional) {
         final var urlBuilder = HttpUrl.parse(target.toString()).newBuilder();
         if (optional != null) {
-            urlBuilder.addEncodedPathSegment(optional);
+            urlBuilder.addPathSegments(optional.startsWith("/") ? optional.substring(1) : optional);
         }
 
         return urlBuilder.build().url();


### PR DESCRIPTION
When the optional path given for an artifact request contains multiple segments, the slashes in between the segments are URL encoded, thus leading to an invalid URL.