### PR TITLE
fix: fix beans not eligable for auto-proxying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Restrict access to POST/PUT/DELETE `{entity}/subscriptions` for artifacts and representations.
+- Fix eager service loading causing "Bean not eligable for..." messages.
 
 ## [6.0.0] - 2021-07-20
 

--- a/src/main/java/io/dataspaceconnector/config/DapsTokenValidator.java
+++ b/src/main/java/io/dataspaceconnector/config/DapsTokenValidator.java
@@ -15,26 +15,27 @@
  */
 package io.dataspaceconnector.config;
 
+import java.io.Serializable;
+
 import io.dataspaceconnector.service.ids.ConnectorService;
-import lombok.AllArgsConstructor;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-
-import java.io.Serializable;
 
 /**
  * This class provides DAT validation.
  */
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public final class DapsTokenValidator implements PermissionEvaluator {
 
     /**
      * Service for providing connector information.
      */
-    private final @NonNull ConnectorService connectorService;
+    private final @NonNull ObjectFactory<ConnectorService> connectorService;
 
     @Override
     public boolean hasPermission(
@@ -57,6 +58,6 @@ public final class DapsTokenValidator implements PermissionEvaluator {
     }
 
     private boolean hasPrivilege() {
-        return connectorService.getCurrentDat() != null;
+        return connectorService.getObject().getCurrentDat() != null;
     }
 }


### PR DESCRIPTION
This fixes auto proxing problems causing e.g.: 
INFO - Bean 'configurationRepository' of type [com.sun.proxy.$Proxy264] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)