### PR TITLE
feat: add operationId tags to OpenApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - New `/actuator/info` API data `connector` to output the current version as well as information if a newer release is available on GitHub.
 - Added `authenticationSet` as boolean indicator in output of configuration APIs whether authentication credentials for a proxy are present.
+- Added operationId - tags to all controller classes to make the operation unique and identifiable
 
 ### Fixed
 - Fix self-reference of QueryInput in OpenApi schema.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27,61 +27,61 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.txt
   version: 6.3.0
 servers:
-- url: https://localhost:8080
-  description: Generated server url
+  - url: https://localhost:8080
+    description: Generated server url
 tags:
-- name: Data Sources/Sinks
-  description: Endpoints for operations on data sources/sinks
-- name: Representations
-  description: Endpoints for operations on representations
-- name: Apps
-  description: Endpoints for app handling
-- name: Artifacts
-  description: Endpoints for operations on artifacts
-- name: Rules
-  description: Endpoints for operations on rules
-- name: Contracts
-  description: Endpoints for operations on contracts
-- name: Endpoints
-  description: Endpoints for operations on endpoints
-- name: Usage Control
-  description: Endpoints for contract/policy handling
-- name: App Stores
-  description: Endpoints for app store handling
-- name: Requested Resources
-  description: Endpoints for operations on requested resources
-- name: Offered Resources
-  description: Endpoints for operations on offered resources
-- name: Connector
-  description: Endpoints for connector information
-- name: Catalogs
-  description: Endpoints for operations on catalogs
-- name: Routes
-  description: Endpoints for operations on routes
-- name: Configurations
-  description: Endpoints for operations on configurations
-- name: Subscriptions
-  description: Endpoints for operations on subscriptions
-- name: Messages
-  description: Endpoints for invoke sending messages
-- name: Agreements
-  description: Endpoints for contract agreement handling
-- name: Brokers
-  description: Endpoints for operations on brokers
+  - name: Data Sources/Sinks
+    description: Endpoints for operations on data sources/sinks
+  - name: Representations
+    description: Endpoints for operations on representations
+  - name: Apps
+    description: Endpoints for app handling
+  - name: Artifacts
+    description: Endpoints for operations on artifacts
+  - name: Rules
+    description: Endpoints for operations on rules
+  - name: Contracts
+    description: Endpoints for operations on contracts
+  - name: Endpoints
+    description: Endpoints for operations on endpoints
+  - name: Usage Control
+    description: Endpoints for contract/policy handling
+  - name: App Stores
+    description: Endpoints for app store handling
+  - name: Requested Resources
+    description: Endpoints for operations on requested resources
+  - name: Offered Resources
+    description: Endpoints for operations on offered resources
+  - name: Connector
+    description: Endpoints for connector information
+  - name: Catalogs
+    description: Endpoints for operations on catalogs
+  - name: Routes
+    description: Endpoints for operations on routes
+  - name: Configurations
+    description: Endpoints for operations on configurations
+  - name: Subscriptions
+    description: Endpoints for operations on subscriptions
+  - name: Messages
+    description: Endpoints for invoke sending messages
+  - name: Agreements
+    description: Endpoints for contract agreement handling
+  - name: Brokers
+    description: Endpoints for operations on brokers
 paths:
   /api/subscriptions/{id}:
     get:
       tags:
-      - Subscriptions
+        - Subscriptions
       summary: Get a base resource by id
-      operationId: get
+      operationId: get_base_resource_by_id
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -97,16 +97,16 @@ paths:
                 $ref: '#/components/schemas/SubscriptionView'
     put:
       tags:
-      - Subscriptions
+        - Subscriptions
       summary: Update a base resource by id
-      operationId: update
+      operationId: put_base_resource_by_id
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -134,16 +134,16 @@ paths:
                 $ref: '#/components/schemas/SubscriptionView'
     delete:
       tags:
-      - Subscriptions
+        - Subscriptions
       summary: Delete a base resource by id
-      operationId: delete
+      operationId: delete_base_resource_by_id
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -152,16 +152,16 @@ paths:
   /api/rules/{id}:
     get:
       tags:
-      - Rules
+        - Rules
       summary: Get a base resource by id
-      operationId: get_1
+      operationId: get_base_resource_by_id_1
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -177,16 +177,16 @@ paths:
                 $ref: '#/components/schemas/ContractRuleView'
     put:
       tags:
-      - Rules
+        - Rules
       summary: Update a base resource by id
-      operationId: update_1
+      operationId: put_base_resource_by_id_1
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -214,16 +214,16 @@ paths:
                 $ref: '#/components/schemas/ContractRuleView'
     delete:
       tags:
-      - Rules
+        - Rules
       summary: Delete a base resource by id
-      operationId: delete_1
+      operationId: delete_base_resource_by_id_1
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -232,30 +232,30 @@ paths:
   /api/rules/{id}/contracts:
     get:
       tags:
-      - Rules
+        - Rules
       summary: Get all children of a base resource with pagination
-      operationId: getResource
+      operationId: get_children_base_resource
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -271,16 +271,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelContractView'
     put:
       tags:
-      - Rules
+        - Rules
       summary: Replace the children of a base resource
-      operationId: replaceResources
+      operationId: put_children_base_resource
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -297,16 +297,16 @@ paths:
           description: No content
     post:
       tags:
-      - Rules
+        - Rules
       summary: Add a list of children to a base resource
-      operationId: addResources
+      operationId: post_children_base_resource
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -331,16 +331,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelContractView'
     delete:
       tags:
-      - Rules
+        - Rules
       summary: Remove a list of children from a base resource
-      operationId: removeResources
+      operationId: delete_children_base_resource
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -358,16 +358,16 @@ paths:
   /api/routes/{id}:
     get:
       tags:
-      - Routes
+        - Routes
       summary: Get a base resource by id
-      operationId: get_2
+      operationId: get_base_resource_by_id_2
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -383,16 +383,16 @@ paths:
                 $ref: '#/components/schemas/RouteView'
     put:
       tags:
-      - Routes
+        - Routes
       summary: Update a base resource by id
-      operationId: update_2
+      operationId: put_base_resource_by_id_2
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -420,16 +420,16 @@ paths:
                 $ref: '#/components/schemas/RouteView'
     delete:
       tags:
-      - Routes
+        - Routes
       summary: Delete a base resource by id
-      operationId: delete_2
+      operationId: delete_base_resource_by_id_2
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -438,30 +438,30 @@ paths:
   /api/routes/{id}/steps:
     get:
       tags:
-      - Routes
+        - Routes
       summary: Get all children of a base resource with pagination
-      operationId: getResource_1
+      operationId: get_children_base_resource_1
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -477,16 +477,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRouteView'
     put:
       tags:
-      - Routes
+        - Routes
       summary: Replace the children of a base resource
-      operationId: replaceResources_1
+      operationId: put_children_base_resource_1
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -503,16 +503,16 @@ paths:
           description: No content
     post:
       tags:
-      - Routes
+        - Routes
       summary: Add a list of children to a base resource
-      operationId: addResources_1
+      operationId: post_children_base_resource_1
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -537,16 +537,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRouteView'
     delete:
       tags:
-      - Routes
+        - Routes
       summary: Remove a list of children from a base resource
-      operationId: removeResources_1
+      operationId: delete_children_base_resource_1
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -564,30 +564,30 @@ paths:
   /api/routes/{id}/outputs:
     get:
       tags:
-      - Routes
+        - Routes
       summary: Get all children of a base resource with pagination
-      operationId: getResource_2
+      operationId: get_children_base_resource_2
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -603,16 +603,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelArtifactView'
     put:
       tags:
-      - Routes
+        - Routes
       summary: Replace the children of a base resource
-      operationId: replaceResources_2
+      operationId: put_children_base_resource_2
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -629,16 +629,16 @@ paths:
           description: No content
     post:
       tags:
-      - Routes
+        - Routes
       summary: Add a list of children to a base resource
-      operationId: addResources_2
+      operationId: post_children_base_resource_2
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -663,16 +663,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelArtifactView'
     delete:
       tags:
-      - Routes
+        - Routes
       summary: Remove a list of children from a base resource
-      operationId: removeResources_2
+      operationId: delete_children_base_resource_2
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -690,16 +690,16 @@ paths:
   /api/routes/{id}/endpoint/start:
     put:
       tags:
-      - Routes
+        - Routes
       summary: Creates start endpoint for the route
-      operationId: createStartEndpoint
+      operationId: put_route_start_endpoint
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -722,16 +722,16 @@ paths:
                 type: string
     delete:
       tags:
-      - Routes
+        - Routes
       summary: Deletes the start endpoint of the route
-      operationId: deleteStartEndpoint
+      operationId: delete_route_endpoint_start
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -748,16 +748,16 @@ paths:
   /api/routes/{id}/endpoint/end:
     put:
       tags:
-      - Routes
+        - Routes
       summary: Creates last endpoint for the route
-      operationId: createLastEndpoint
+      operationId: put_route_end_endpoint
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -780,16 +780,16 @@ paths:
                 type: string
     delete:
       tags:
-      - Routes
-      summary: Deletes the start endpoint of the route
-      operationId: deleteLastEndpoint
+        - Routes
+      summary: Deletes the last endpoint of the route
+      operationId: delete_route_end_endpoint
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -806,16 +806,16 @@ paths:
   /api/requests/{id}:
     get:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Get a base resource by id
-      operationId: get_3
+      operationId: get_base_resource_by_id_3
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -831,16 +831,16 @@ paths:
                 $ref: '#/components/schemas/RequestedResourceView'
     put:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Update a base resource by id
-      operationId: update_3
+      operationId: put_base_resource_by_id_3
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -868,16 +868,16 @@ paths:
                 $ref: '#/components/schemas/RequestedResourceView'
     delete:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Delete a base resource by id
-      operationId: delete_3
+      operationId: delete_base_resource_by_id_3
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -886,30 +886,30 @@ paths:
   /api/requests/{id}/representations:
     get:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Get all children of a base resource with pagination
-      operationId: getResource_4
+      operationId: get_children_base_resource_4
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -925,16 +925,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRepresentationView'
     put:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Replace the children of a base resource
-      operationId: replaceResources_3
+      operationId: put_children_base_resource_3
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -951,16 +951,16 @@ paths:
           description: No content
     post:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Add a list of children to a base resource
-      operationId: addResources_3
+      operationId: post_children_base_resource_3
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -985,16 +985,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRepresentationView'
     delete:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Remove a list of children from a base resource
-      operationId: removeResources_3
+      operationId: delete_children_base_resource_3
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1012,30 +1012,30 @@ paths:
   /api/requests/{id}/catalogs:
     get:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Get all children of a base resource with pagination
-      operationId: getResource_6
+      operationId: get_children_base_resource_6
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -1051,16 +1051,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelCatalogView'
     put:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Replace the children of a base resource
-      operationId: replaceResources_4
+      operationId: put_children_base_resource_4
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1077,16 +1077,16 @@ paths:
           description: No content
     post:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Add a list of children to a base resource
-      operationId: addResources_4
+      operationId: post_children_base_resource_4
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1111,16 +1111,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelCatalogView'
     delete:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Remove a list of children from a base resource
-      operationId: removeResources_4
+      operationId: delete_children_base_resource_4
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1138,16 +1138,16 @@ paths:
   /api/representations/{id}:
     get:
       tags:
-      - Representations
+        - Representations
       summary: Get a base resource by id
-      operationId: get_4
+      operationId: get_base_resource_by_id_4
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -1163,16 +1163,16 @@ paths:
                 $ref: '#/components/schemas/RepresentationView'
     put:
       tags:
-      - Representations
+        - Representations
       summary: Update a base resource by id
-      operationId: update_4
+      operationId: put_base_resource_by_id_4
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1200,16 +1200,16 @@ paths:
                 $ref: '#/components/schemas/RepresentationView'
     delete:
       tags:
-      - Representations
+        - Representations
       summary: Delete a base resource by id
-      operationId: delete_4
+      operationId: delete_base_resource_by_id_4
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -1218,30 +1218,30 @@ paths:
   /api/representations/{id}/requests:
     get:
       tags:
-      - Representations
+        - Representations
       summary: Get all children of a base resource with pagination
-      operationId: getResource_8
+      operationId: get_children_base_resource_8
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -1257,16 +1257,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRequestedResourceView'
     put:
       tags:
-      - Representations
+        - Representations
       summary: Replace the children of a base resource
-      operationId: replaceResources_5
+      operationId: put_children_base_resource_5
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1283,16 +1283,16 @@ paths:
           description: No content
     post:
       tags:
-      - Representations
+        - Representations
       summary: Add a list of children to a base resource
-      operationId: addResources_5
+      operationId: post_children_base_resource_5
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1317,16 +1317,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRequestedResourceView'
     delete:
       tags:
-      - Representations
+        - Representations
       summary: Remove a list of children from a base resource
-      operationId: removeResources_5
+      operationId: delete_children_base_resource_5
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1344,30 +1344,30 @@ paths:
   /api/representations/{id}/offers:
     get:
       tags:
-      - Representations
+        - Representations
       summary: Get all children of a base resource with pagination
-      operationId: getResource_9
+      operationId: get_children_base_resource_9
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -1383,16 +1383,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelOfferedResourceView'
     put:
       tags:
-      - Representations
+        - Representations
       summary: Replace the children of a base resource
-      operationId: replaceResources_6
+      operationId: put_children_base_resource_6
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1409,16 +1409,16 @@ paths:
           description: No content
     post:
       tags:
-      - Representations
+        - Representations
       summary: Add a list of children to a base resource
-      operationId: addResources_6
+      operationId: post_children_base_resource_6
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1443,16 +1443,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelOfferedResourceView'
     delete:
       tags:
-      - Representations
+        - Representations
       summary: Remove a list of children from a base resource
-      operationId: removeResources_6
+      operationId: delete_children_base_resource_6
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1470,30 +1470,30 @@ paths:
   /api/representations/{id}/artifacts:
     get:
       tags:
-      - Representations
+        - Representations
       summary: Get all children of a base resource with pagination
-      operationId: getResource_10
+      operationId: get_children_base_resource_10
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -1509,16 +1509,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelArtifactView'
     put:
       tags:
-      - Representations
+        - Representations
       summary: Replace the children of a base resource
-      operationId: replaceResources_7
+      operationId: put_children_base_resource_7
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1535,16 +1535,16 @@ paths:
           description: No content
     post:
       tags:
-      - Representations
+        - Representations
       summary: Add a list of children to a base resource
-      operationId: addResources_7
+      operationId: post_children_base_resource_7
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1569,16 +1569,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelArtifactView'
     delete:
       tags:
-      - Representations
+        - Representations
       summary: Remove a list of children from a base resource
-      operationId: removeResources_7
+      operationId: delete_children_base_resource_7
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1596,16 +1596,16 @@ paths:
   /api/offers/{id}:
     get:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Get a base resource by id
-      operationId: get_5
+      operationId: get_base_resource_by_id_5
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -1621,16 +1621,16 @@ paths:
                 $ref: '#/components/schemas/OfferedResourceView'
     put:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Update a base resource by id
-      operationId: update_5
+      operationId: put_base_resource_by_id_5
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1658,16 +1658,16 @@ paths:
                 $ref: '#/components/schemas/OfferedResourceView'
     delete:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Delete a base resource by id
-      operationId: delete_5
+      operationId: delete_base_resource_by_id_5
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -1676,30 +1676,30 @@ paths:
   /api/offers/{id}/representations:
     get:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Get all children of a base resource with pagination
-      operationId: getResource_12
+      operationId: get_children_base_resource_12
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -1715,16 +1715,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRepresentationView'
     put:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Replace the children of a base resource
-      operationId: replaceResources_8
+      operationId: put_children_base_resource_8
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1741,16 +1741,16 @@ paths:
           description: No content
     post:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Add a list of children to a base resource
-      operationId: addResources_8
+      operationId: post_children_base_resource_8
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1775,16 +1775,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRepresentationView'
     delete:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Remove a list of children from a base resource
-      operationId: removeResources_8
+      operationId: delete_children_base_resource_8
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1802,30 +1802,30 @@ paths:
   /api/offers/{id}/contracts:
     get:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Get all children of a base resource with pagination
-      operationId: getResource_13
+      operationId: get_children_base_resource_13
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -1841,16 +1841,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelContractView'
     put:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Replace the children of a base resource
-      operationId: replaceResources_9
+      operationId: put_children_base_resource_9
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1867,16 +1867,16 @@ paths:
           description: No content
     post:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Add a list of children to a base resource
-      operationId: addResources_9
+      operationId: post_children_base_resource_9
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1901,16 +1901,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelContractView'
     delete:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Remove a list of children from a base resource
-      operationId: removeResources_9
+      operationId: delete_children_base_resource_9
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1928,30 +1928,30 @@ paths:
   /api/offers/{id}/catalogs:
     get:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Get all children of a base resource with pagination
-      operationId: getResource_14
+      operationId: get_children_base_resource_14
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -1967,16 +1967,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelCatalogView'
     put:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Replace the children of a base resource
-      operationId: replaceResources_10
+      operationId: put_children_base_resource_10
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1993,16 +1993,16 @@ paths:
           description: No content
     post:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Add a list of children to a base resource
-      operationId: addResources_10
+      operationId: post_children_base_resource_10
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2027,16 +2027,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelCatalogView'
     delete:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Remove a list of children from a base resource
-      operationId: removeResources_10
+      operationId: delete_children_base_resource_10
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2054,19 +2054,19 @@ paths:
   /api/notify:
     put:
       tags:
-      - Messages
+        - Messages
       summary: Notify all subscribers
       description: "Can be used to manually notify all subscribers about a resource\
         \ offer, representation, or artifact update."
-      operationId: sendMessage
+      operationId: put_notify_subscribers
       parameters:
-      - name: elementId
-        in: query
-        description: The element id.
-        required: true
-        schema:
-          type: string
-          format: uri
+        - name: elementId
+          in: query
+          description: The element id.
+          required: true
+          schema:
+            type: string
+            format: uri
       responses:
         "401":
           description: Unauthorized
@@ -2095,16 +2095,16 @@ paths:
   /api/endpoints/{id}:
     get:
       tags:
-      - Endpoints
+        - Endpoints
       summary: Get a base resource by id
-      operationId: get_6
+      operationId: get_base_resource_by_id_6
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2120,25 +2120,25 @@ paths:
                 type: object
     put:
       tags:
-      - Endpoints
+        - Endpoints
       summary: Update a base resource by id
-      operationId: update_6
+      operationId: put_base_resource_by_id_6
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
             schema:
               oneOf:
-              - $ref: '#/components/schemas/EndpointDesc'
-              - $ref: '#/components/schemas/AppEndpointDesc'
-              - $ref: '#/components/schemas/ConnectorEndpointDesc'
-              - $ref: '#/components/schemas/GenericEndpointDesc'
+                - $ref: '#/components/schemas/EndpointDesc'
+                - $ref: '#/components/schemas/AppEndpointDesc'
+                - $ref: '#/components/schemas/ConnectorEndpointDesc'
+                - $ref: '#/components/schemas/GenericEndpointDesc'
         required: true
       responses:
         "401":
@@ -2161,16 +2161,16 @@ paths:
                 type: object
     delete:
       tags:
-      - Endpoints
+        - Endpoints
       summary: Delete a base resource by id
-      operationId: delete_6
+      operationId: delete_base_resource_by_id_6
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2179,22 +2179,22 @@ paths:
   /api/endpoints/{id}/datasource/{dataSourceId}:
     put:
       tags:
-      - Endpoints
+        - Endpoints
       summary: Creates start endpoint for the route
-      operationId: linkDataSource
+      operationId: put_route_start_endpoint_1
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: dataSourceId
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: dataSourceId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2203,16 +2203,16 @@ paths:
   /api/datasources/{id}:
     get:
       tags:
-      - Data Sources/Sinks
+        - Data Sources/Sinks
       summary: Get a base resource by id
-      operationId: get_7
+      operationId: get_base_resource_by_id_7
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2228,16 +2228,16 @@ paths:
                 $ref: '#/components/schemas/DataSourceView'
     put:
       tags:
-      - Data Sources/Sinks
+        - Data Sources/Sinks
       summary: Update a base resource by id
-      operationId: update_7
+      operationId: put_base_resource_by_id_7
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2265,16 +2265,16 @@ paths:
                 $ref: '#/components/schemas/DataSourceView'
     delete:
       tags:
-      - Data Sources/Sinks
+        - Data Sources/Sinks
       summary: Delete a base resource by id
-      operationId: delete_7
+      operationId: delete_base_resource_by_id_7
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2283,16 +2283,16 @@ paths:
   /api/contracts/{id}:
     get:
       tags:
-      - Contracts
+        - Contracts
       summary: Get a base resource by id
-      operationId: get_8
+      operationId: get_base_resource_by_id_8
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2308,16 +2308,16 @@ paths:
                 $ref: '#/components/schemas/ContractView'
     put:
       tags:
-      - Contracts
+        - Contracts
       summary: Update a base resource by id
-      operationId: update_8
+      operationId: put_base_resource_by_id_8
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2345,16 +2345,16 @@ paths:
                 $ref: '#/components/schemas/ContractView'
     delete:
       tags:
-      - Contracts
+        - Contracts
       summary: Delete a base resource by id
-      operationId: delete_8
+      operationId: delete_base_resource_by_id_8
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2363,30 +2363,30 @@ paths:
   /api/contracts/{id}/rules:
     get:
       tags:
-      - Contracts
+        - Contracts
       summary: Get all children of a base resource with pagination
-      operationId: getResource_16
+      operationId: get_children_base_resource_16
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -2402,16 +2402,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelContractRuleView'
     put:
       tags:
-      - Contracts
+        - Contracts
       summary: Replace the children of a base resource
-      operationId: replaceResources_11
+      operationId: put_children_base_resource_11
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2428,16 +2428,16 @@ paths:
           description: No content
     post:
       tags:
-      - Contracts
+        - Contracts
       summary: Add a list of children to a base resource
-      operationId: addResources_11
+      operationId: post_children_base_resource_11
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2462,16 +2462,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelContractRuleView'
     delete:
       tags:
-      - Contracts
+        - Contracts
       summary: Remove a list of children from a base resource
-      operationId: removeResources_11
+      operationId: delete_children_base_resource_11
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2489,30 +2489,30 @@ paths:
   /api/contracts/{id}/offers:
     get:
       tags:
-      - Contracts
+        - Contracts
       summary: Get all children of a base resource with pagination
-      operationId: getResource_18
+      operationId: get_children_base_resource_18
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -2528,16 +2528,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelOfferedResourceView'
     put:
       tags:
-      - Contracts
+        - Contracts
       summary: Replace the children of a base resource
-      operationId: replaceResources_12
+      operationId: put_children_base_resource_12
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2554,16 +2554,16 @@ paths:
           description: No content
     post:
       tags:
-      - Contracts
+        - Contracts
       summary: Add a list of children to a base resource
-      operationId: addResources_12
+      operationId: post_children_base_resource_12
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2588,16 +2588,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelOfferedResourceView'
     delete:
       tags:
-      - Contracts
+        - Contracts
       summary: Remove a list of children from a base resource
-      operationId: removeResources_12
+      operationId: delete_children_base_resource_12
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2615,16 +2615,16 @@ paths:
   /api/configurations/{id}:
     get:
       tags:
-      - Configurations
+        - Configurations
       summary: Get a base resource by id
-      operationId: get_9
+      operationId: get_base_resource_by_id_9
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2640,16 +2640,16 @@ paths:
                 $ref: '#/components/schemas/ConfigurationView'
     put:
       tags:
-      - Configurations
+        - Configurations
       summary: Update a base resource by id
-      operationId: update_9
+      operationId: put_base_resource_by_id_9
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2677,16 +2677,16 @@ paths:
                 $ref: '#/components/schemas/ConfigurationView'
     delete:
       tags:
-      - Configurations
+        - Configurations
       summary: Delete a base resource by id
-      operationId: delete_9
+      operationId: delete_base_resource_by_id_9
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2695,16 +2695,16 @@ paths:
   /api/configurations/{id}/active:
     put:
       tags:
-      - Configurations
+        - Configurations
       summary: Update current configuration
-      operationId: setConfiguration
+      operationId: put_active_config
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2739,10 +2739,10 @@ paths:
   /api/configuration/pattern:
     get:
       tags:
-      - Usage Control
+        - Usage Control
       summary: Get pattern validation status
       description: Return if unsupported patterns are ignored when requesting data.
-      operationId: getPatternStatus
+      operationId: get_pattern_status
       responses:
         "401":
           description: Unauthorized
@@ -2768,17 +2768,17 @@ paths:
                   type: object
     put:
       tags:
-      - Usage Control
+        - Usage Control
       summary: Allow unsupported patterns
       description: Allow requesting data without policy enforcement if an unsupported
         pattern is recognized.
-      operationId: setPatternStatus
+      operationId: put_pattern_status
       parameters:
-      - name: status
-        in: query
-        required: true
-        schema:
-          type: boolean
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: boolean
       responses:
         "401":
           description: Unauthorized
@@ -2805,9 +2805,9 @@ paths:
   /api/configuration/negotiation:
     get:
       tags:
-      - Usage Control
+        - Usage Control
       summary: Get contract negotiation status
-      operationId: getNegotiationStatus
+      operationId: get_contract_negotiation
       responses:
         "401":
           description: Unauthorized
@@ -2833,15 +2833,15 @@ paths:
                   type: object
     put:
       tags:
-      - Usage Control
+        - Usage Control
       summary: Set contract negotiation status
-      operationId: setNegotiationStatus
+      operationId: put_contract_negotiation
       parameters:
-      - name: status
-        in: query
-        required: true
-        schema:
-          type: boolean
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: boolean
       responses:
         "401":
           description: Unauthorized
@@ -2868,16 +2868,16 @@ paths:
   /api/catalogs/{id}:
     get:
       tags:
-      - Catalogs
+        - Catalogs
       summary: Get a base resource by id
-      operationId: get_10
+      operationId: get_base_resource_by_id_10
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2893,16 +2893,16 @@ paths:
                 $ref: '#/components/schemas/CatalogView'
     put:
       tags:
-      - Catalogs
+        - Catalogs
       summary: Update a base resource by id
-      operationId: update_10
+      operationId: put_base_resource_by_id_10
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2930,16 +2930,16 @@ paths:
                 $ref: '#/components/schemas/CatalogView'
     delete:
       tags:
-      - Catalogs
+        - Catalogs
       summary: Delete a base resource by id
-      operationId: delete_10
+      operationId: delete_base_resource_by_id_10
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -2948,30 +2948,30 @@ paths:
   /api/catalogs/{id}/offers:
     get:
       tags:
-      - Catalogs
+        - Catalogs
       summary: Get all children of a base resource with pagination
-      operationId: getResource_19
+      operationId: get_children_base_resource_19
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -2987,16 +2987,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelOfferedResourceView'
     put:
       tags:
-      - Catalogs
+        - Catalogs
       summary: Replace the children of a base resource
-      operationId: replaceResources_13
+      operationId: put_children_base_resource_13
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3013,16 +3013,16 @@ paths:
           description: No content
     post:
       tags:
-      - Catalogs
+        - Catalogs
       summary: Add a list of children to a base resource
-      operationId: addResources_13
+      operationId: post_children_base_resource_13
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3047,16 +3047,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelOfferedResourceView'
     delete:
       tags:
-      - Catalogs
+        - Catalogs
       summary: Remove a list of children from a base resource
-      operationId: removeResources_13
+      operationId: delete_children_base_resource_13
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3074,16 +3074,16 @@ paths:
   /api/brokers/{id}:
     get:
       tags:
-      - Brokers
+        - Brokers
       summary: Get a base resource by id
-      operationId: get_11
+      operationId: get_base_resource_by_id_11
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -3099,16 +3099,16 @@ paths:
                 $ref: '#/components/schemas/BrokerView'
     put:
       tags:
-      - Brokers
+        - Brokers
       summary: Update a base resource by id
-      operationId: update_11
+      operationId: put_base_resource_by_id_11
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3136,16 +3136,16 @@ paths:
                 $ref: '#/components/schemas/BrokerView'
     delete:
       tags:
-      - Brokers
+        - Brokers
       summary: Delete a base resource by id
-      operationId: delete_11
+      operationId: delete_base_resource_by_id_11
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -3154,16 +3154,16 @@ paths:
   /api/artifacts/{id}:
     get:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Get a base resource by id
-      operationId: get_12
+      operationId: get_base_resource_by_id_12
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -3179,16 +3179,16 @@ paths:
                 $ref: '#/components/schemas/ArtifactView'
     put:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Update a base resource by id
-      operationId: update_12
+      operationId: put_base_resource_by_id_12
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3216,16 +3216,16 @@ paths:
                 $ref: '#/components/schemas/ArtifactView'
     delete:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Delete a base resource by id
-      operationId: delete_12
+      operationId: delete_base_resource_by_id_12
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -3234,30 +3234,30 @@ paths:
   /api/artifacts/{id}/representations:
     get:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Get all children of a base resource with pagination
-      operationId: getResource_22
+      operationId: get_children_base_resource_22
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -3273,16 +3273,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRepresentationView'
     put:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Replace the children of a base resource
-      operationId: replaceResources_14
+      operationId: put_children_base_resource_14
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3299,16 +3299,16 @@ paths:
           description: No content
     post:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Add a list of children to a base resource
-      operationId: addResources_14
+      operationId: post_children_base_resource_14
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3333,16 +3333,16 @@ paths:
                 $ref: '#/components/schemas/PagedModelRepresentationView'
     delete:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Remove a list of children from a base resource
-      operationId: removeResources_14
+      operationId: delete_children_base_resource_14
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3360,15 +3360,15 @@ paths:
   /api/artifacts/{id}/data:
     put:
       tags:
-      - Artifacts
+        - Artifacts
       operationId: putData
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           '*/*':
@@ -3385,16 +3385,16 @@ paths:
           description: Ok
     post:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Get data by artifact id with query input
-      operationId: getData
+      operationId: get_data_by_artifact_id_2
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json: {}
@@ -3414,16 +3414,16 @@ paths:
   /api/appstores/{id}:
     get:
       tags:
-      - App Stores
+        - App Stores
       summary: Get a base resource by id
-      operationId: get_13
+      operationId: get_base_resource_by_id_13
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -3439,16 +3439,16 @@ paths:
                 $ref: '#/components/schemas/AppStoreView'
     put:
       tags:
-      - App Stores
+        - App Stores
       summary: Update a base resource by id
-      operationId: update_13
+      operationId: put_base_resource_by_id_13
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3476,16 +3476,16 @@ paths:
                 $ref: '#/components/schemas/AppStoreView'
     delete:
       tags:
-      - App Stores
+        - App Stores
       summary: Delete a base resource by id
-      operationId: delete_13
+      operationId: delete_base_resource_by_id_13
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -3494,22 +3494,22 @@ paths:
   /api/apps/{id}/actions:
     put:
       tags:
-      - Apps
+        - Apps
       summary: Actions on apps
       description: Can be used for managing apps.
-      operationId: containerManagement
+      operationId: put_app_action
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: actionType
-        in: query
-        required: true
-        schema:
-          type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: actionType
+          in: query
+          required: true
+          schema:
+            type: string
       responses:
         "401":
           description: Unauthorized
@@ -3538,24 +3538,24 @@ paths:
   /api/subscriptions:
     get:
       tags:
-      - Subscriptions
+        - Subscriptions
       summary: Get a list of base resources with pagination
-      operationId: getAll
+      operationId: get_base_resources
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -3571,9 +3571,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelSubscriptionView'
     post:
       tags:
-      - Subscriptions
+        - Subscriptions
       summary: Create a base resource
-      operationId: create
+      operationId: post_subscription
       requestBody:
         content:
           application/json:
@@ -3596,24 +3596,24 @@ paths:
   /api/rules:
     get:
       tags:
-      - Rules
+        - Rules
       summary: Get a list of base resources with pagination
-      operationId: getAll_1
+      operationId: get_base_resources_1
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -3629,9 +3629,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelContractRuleView'
     post:
       tags:
-      - Rules
+        - Rules
       summary: Create a base resource
-      operationId: create_1
+      operationId: post_base_resource
       requestBody:
         content:
           application/json:
@@ -3654,24 +3654,24 @@ paths:
   /api/routes:
     get:
       tags:
-      - Routes
+        - Routes
       summary: Get a list of base resources with pagination
-      operationId: getAll_2
+      operationId: get_base_resources_2
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -3687,9 +3687,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelRouteView'
     post:
       tags:
-      - Routes
+        - Routes
       summary: Create a base resource
-      operationId: create_2
+      operationId: post_base_resource_1
       requestBody:
         content:
           application/json:
@@ -3712,24 +3712,24 @@ paths:
   /api/representations:
     get:
       tags:
-      - Representations
+        - Representations
       summary: Get a list of base resources with pagination
-      operationId: getAll_4
+      operationId: get_base_resources_4
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -3745,9 +3745,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelRepresentationView'
     post:
       tags:
-      - Representations
+        - Representations
       summary: Create a base resource
-      operationId: create_3
+      operationId: post_base_resource_2
       requestBody:
         content:
           application/json:
@@ -3770,24 +3770,24 @@ paths:
   /api/offers:
     get:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Get a list of base resources with pagination
-      operationId: getAll_5
+      operationId: get_base_resources_5
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -3803,9 +3803,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelOfferedResourceView'
     post:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Create a base resource
-      operationId: create_4
+      operationId: post_base_resource_3
       requestBody:
         content:
           application/json:
@@ -3828,24 +3828,24 @@ paths:
   /api/ids/unsubscribe:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Send IDS request message for element unsubscription
-      operationId: unsubscribe
+      operationId: post_send_element_unsubscribe_message
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
-      - name: elementId
-        in: query
-        description: The subscription object.
-        required: true
-        schema:
-          type: string
-          format: uri
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
+        - name: elementId
+          in: query
+          description: The subscription object.
+          required: true
+          schema:
+            type: string
+            format: uri
       responses:
         "401":
           description: Unauthorized
@@ -3874,17 +3874,17 @@ paths:
   /api/ids/subscribe:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Send IDS request message for element subscription
-      operationId: subscribe
+      operationId: post_send_element_subscribe_message
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
       requestBody:
         content:
           application/json:
@@ -3925,35 +3925,35 @@ paths:
   /api/ids/search:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Full text search
       description: Can be used for full text search at an IDS component (e.g. the
         Broker).
-      operationId: sendSearchMessage
+      operationId: post_send_full_text_query_message
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
-      - name: limit
-        in: query
-        description: The limit value.
-        required: true
-        schema:
-          type: integer
-          format: int32
-          default: 50
-      - name: offset
-        in: query
-        description: The offset value.
-        required: true
-        schema:
-          type: integer
-          format: int32
-          default: 0
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
+        - name: limit
+          in: query
+          description: The limit value.
+          required: true
+          schema:
+            type: integer
+            format: int32
+            default: 50
+        - name: offset
+          in: query
+          description: The offset value.
+          required: true
+          schema:
+            type: integer
+            format: int32
+            default: 0
       requestBody:
         content:
           application/json:
@@ -3995,26 +3995,26 @@ paths:
   /api/ids/resource/update:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Resource update message
       description: Can be used for registering or updating a resource at an IDS broker
         or consumer connector.
-      operationId: sendMessage_1
+      operationId: update_resource
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
-      - name: resourceId
-        in: query
-        description: The resource id.
-        required: true
-        schema:
-          type: string
-          format: uri
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
+        - name: resourceId
+          in: query
+          description: The resource id.
+          required: true
+          schema:
+            type: string
+            format: uri
       responses:
         "401":
           description: Unauthorized
@@ -4061,25 +4061,25 @@ paths:
   /api/ids/resource/unavailable:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Resource unavailable message
       description: Can be used for e.g. unregistering a resource at an IDS broker.
-      operationId: sendMessage_2
+      operationId: post_send_resource_unavailable_message
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
-      - name: resourceId
-        in: query
-        description: The resource id.
-        required: true
-        schema:
-          type: string
-          format: uri
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
+        - name: resourceId
+          in: query
+          description: The resource id.
+          required: true
+          schema:
+            type: string
+            format: uri
       responses:
         "401":
           description: Unauthorized
@@ -4126,18 +4126,18 @@ paths:
   /api/ids/query:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Query message
       description: Can be used for querying an IDS component (e.g. the Broker).
-      operationId: sendQueryMessage
+      operationId: post_send_query_message
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
       requestBody:
         content:
           application/json:
@@ -4191,24 +4191,24 @@ paths:
   /api/ids/description:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Send IDS description request message
-      operationId: sendMessage_3
+      operationId: post_send_description_request_message
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
-      - name: elementId
-        in: query
-        description: The id of the requested resource.
-        required: false
-        schema:
-          type: string
-          format: uri
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
+        - name: elementId
+          in: query
+          description: The id of the requested resource.
+          required: false
+          schema:
+            type: string
+            format: uri
       responses:
         "401":
           description: Unauthorized
@@ -4243,42 +4243,42 @@ paths:
   /api/ids/contract:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Send IDS contract request message
-      operationId: sendMessage_4
+      operationId: post_send_contract_request_message
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
-      - name: resourceIds
-        in: query
-        description: List of ids resource that should be requested.
-        required: true
-        schema:
-          type: array
-          items:
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
             type: string
             format: uri
-      - name: artifactIds
-        in: query
-        description: List of ids artifacts that should be requested.
-        required: true
-        schema:
-          type: array
-          items:
-            type: string
-            format: uri
-      - name: download
-        in: query
-        description: Indicates whether the connector should automatically download
-          data of an artifact.
-        required: true
-        schema:
-          type: boolean
+        - name: resourceIds
+          in: query
+          description: List of ids resource that should be requested.
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              format: uri
+        - name: artifactIds
+          in: query
+          description: List of ids artifacts that should be requested.
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              format: uri
+        - name: download
+          in: query
+          description: Indicates whether the connector should automatically download
+            data of an artifact.
+          required: true
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:
@@ -4287,9 +4287,9 @@ paths:
               description: List of ids rules with an artifact id as target.
               items:
                 oneOf:
-                - $ref: '#/components/schemas/Duty'
-                - $ref: '#/components/schemas/Permission'
-                - $ref: '#/components/schemas/Prohibition'
+                  - $ref: '#/components/schemas/Duty'
+                  - $ref: '#/components/schemas/Permission'
+                  - $ref: '#/components/schemas/Prohibition'
         required: true
       responses:
         "401":
@@ -4337,19 +4337,19 @@ paths:
   /api/ids/connector/update:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Connector update message
       description: Can be used for registering or updating the connector at an IDS
         broker.
-      operationId: sendMessage_5
+      operationId: post_send_connector_update_message
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
       responses:
         "401":
           description: Unauthorized
@@ -4390,18 +4390,18 @@ paths:
   /api/ids/connector/unavailable:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Connector unavailable message
       description: Can be used for unregistering the connector at an IDS broker.
-      operationId: sendMessage_6
+      operationId: post_send_connector_unavailable_message
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
       responses:
         "401":
           description: Unauthorized
@@ -4442,24 +4442,24 @@ paths:
   /api/ids/app:
     post:
       tags:
-      - Messages
+        - Messages
       summary: Download IDS app from AppStore
-      operationId: sendMessage_7
+      operationId: post_download_ids_app
       parameters:
-      - name: recipient
-        in: query
-        description: The recipient url.
-        required: true
-        schema:
-          type: string
-          format: uri
-      - name: appId
-        in: query
-        description: The app id.
-        required: true
-        schema:
-          type: string
-          format: uri
+        - name: recipient
+          in: query
+          description: The recipient url.
+          required: true
+          schema:
+            type: string
+            format: uri
+        - name: appId
+          in: query
+          description: The app id.
+          required: true
+          schema:
+            type: string
+            format: uri
       responses:
         "401":
           description: Unauthorized
@@ -4506,10 +4506,10 @@ paths:
   /api/examples/validation:
     post:
       tags:
-      - Usage Control
+        - Usage Control
       summary: Get pattern of policy
       description: Get the policy pattern represented by a given JSON string.
-      operationId: getPolicyPattern
+      operationId: post_get_policy_pattern
       requestBody:
         content:
           application/json:
@@ -4539,26 +4539,26 @@ paths:
   /api/examples/policy:
     post:
       tags:
-      - Usage Control
+        - Usage Control
       summary: Get example policy
       description: Get an example policy for a given policy pattern.
-      operationId: getExampleUsagePolicy
+      operationId: post_get_example_policy
       requestBody:
         content:
           application/json:
             schema:
               oneOf:
-              - $ref: '#/components/schemas/PatternDesc'
-              - $ref: '#/components/schemas/ConnectorRestrictionDesc'
-              - $ref: '#/components/schemas/DeletionDesc'
-              - $ref: '#/components/schemas/DurationDesc'
-              - $ref: '#/components/schemas/IntervalDesc'
-              - $ref: '#/components/schemas/LoggingDesc'
-              - $ref: '#/components/schemas/NotificationDesc'
-              - $ref: '#/components/schemas/PermissionDesc'
-              - $ref: '#/components/schemas/ProhibitionDesc'
-              - $ref: '#/components/schemas/SecurityRestrictionDesc'
-              - $ref: '#/components/schemas/UsageNumberDesc'
+                - $ref: '#/components/schemas/PatternDesc'
+                - $ref: '#/components/schemas/ConnectorRestrictionDesc'
+                - $ref: '#/components/schemas/DeletionDesc'
+                - $ref: '#/components/schemas/DurationDesc'
+                - $ref: '#/components/schemas/IntervalDesc'
+                - $ref: '#/components/schemas/LoggingDesc'
+                - $ref: '#/components/schemas/NotificationDesc'
+                - $ref: '#/components/schemas/PermissionDesc'
+                - $ref: '#/components/schemas/ProhibitionDesc'
+                - $ref: '#/components/schemas/SecurityRestrictionDesc'
+                - $ref: '#/components/schemas/UsageNumberDesc'
         required: true
       responses:
         "401":
@@ -4582,24 +4582,24 @@ paths:
   /api/endpoints:
     get:
       tags:
-      - Endpoints
+        - Endpoints
       summary: Get a list of base resources with pagination
-      operationId: getAll_6
+      operationId: get_base_resources_6
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -4615,18 +4615,18 @@ paths:
                 $ref: '#/components/schemas/PagedModelObject'
     post:
       tags:
-      - Endpoints
+        - Endpoints
       summary: Create a base resource
-      operationId: create_5
+      operationId: post_base_resource_4
       requestBody:
         content:
           application/json:
             schema:
               oneOf:
-              - $ref: '#/components/schemas/EndpointDesc'
-              - $ref: '#/components/schemas/AppEndpointDesc'
-              - $ref: '#/components/schemas/ConnectorEndpointDesc'
-              - $ref: '#/components/schemas/GenericEndpointDesc'
+                - $ref: '#/components/schemas/EndpointDesc'
+                - $ref: '#/components/schemas/AppEndpointDesc'
+                - $ref: '#/components/schemas/ConnectorEndpointDesc'
+                - $ref: '#/components/schemas/GenericEndpointDesc'
         required: true
       responses:
         "401":
@@ -4644,24 +4644,24 @@ paths:
   /api/datasources:
     get:
       tags:
-      - Data Sources/Sinks
+        - Data Sources/Sinks
       summary: Get a list of base resources with pagination
-      operationId: getAll_7
+      operationId: get_base_resources_7
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -4677,9 +4677,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelDataSourceView'
     post:
       tags:
-      - Data Sources/Sinks
+        - Data Sources/Sinks
       summary: Create a base resource
-      operationId: create_6
+      operationId: post_base_resource_5
       requestBody:
         content:
           application/json:
@@ -4702,24 +4702,24 @@ paths:
   /api/contracts:
     get:
       tags:
-      - Contracts
+        - Contracts
       summary: Get a list of base resources with pagination
-      operationId: getAll_8
+      operationId: get_base_resources_8
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -4735,9 +4735,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelContractView'
     post:
       tags:
-      - Contracts
+        - Contracts
       summary: Create a base resource
-      operationId: create_7
+      operationId: post_base_resource_6
       requestBody:
         content:
           application/json:
@@ -4760,24 +4760,24 @@ paths:
   /api/configurations:
     get:
       tags:
-      - Configurations
+        - Configurations
       summary: Get a list of base resources with pagination
-      operationId: getAll_9
+      operationId: get_base_resources_9
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -4793,9 +4793,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelConfigurationView'
     post:
       tags:
-      - Configurations
+        - Configurations
       summary: Create a base resource
-      operationId: create_8
+      operationId: post_base_resource_7
       requestBody:
         content:
           application/json:
@@ -4818,24 +4818,24 @@ paths:
   /api/catalogs:
     get:
       tags:
-      - Catalogs
+        - Catalogs
       summary: Get a list of base resources with pagination
-      operationId: getAll_10
+      operationId: get_base_resources_10
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -4851,9 +4851,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelCatalogView'
     post:
       tags:
-      - Catalogs
+        - Catalogs
       summary: Create a base resource
-      operationId: create_9
+      operationId: post_base_resource_8
       requestBody:
         content:
           application/json:
@@ -4876,24 +4876,24 @@ paths:
   /api/brokers:
     get:
       tags:
-      - Brokers
+        - Brokers
       summary: Get a list of base resources with pagination
-      operationId: getAll_11
+      operationId: get_base_resources_11
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -4909,9 +4909,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelBrokerView'
     post:
       tags:
-      - Brokers
+        - Brokers
       summary: Create a base resource
-      operationId: create_10
+      operationId: post_base_resource_9
       requestBody:
         content:
           application/json:
@@ -4934,24 +4934,24 @@ paths:
   /api/artifacts:
     get:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Get a list of base resources with pagination
-      operationId: getAll_12
+      operationId: get_base_resources_12
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -4967,9 +4967,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelArtifactView'
     post:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Create a base resource
-      operationId: create_11
+      operationId: post_base_resource_10
       requestBody:
         content:
           application/json:
@@ -4992,24 +4992,24 @@ paths:
   /api/appstores:
     get:
       tags:
-      - App Stores
+        - App Stores
       summary: Get a list of base resources with pagination
-      operationId: getAll_13
+      operationId: get_base_resources_13
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5025,9 +5025,9 @@ paths:
                 $ref: '#/components/schemas/PagedModelAppStoreView'
     post:
       tags:
-      - App Stores
+        - App Stores
       summary: Create a base resource
-      operationId: create_12
+      operationId: post_base_resource_11
       requestBody:
         content:
           application/json:
@@ -5050,23 +5050,24 @@ paths:
   /api/subscriptions/owning:
     get:
       tags:
-      - Subscriptions
-      operationId: getAllFiltered
+        - Subscriptions
+      summary: get list of all subscriptions
+      operationId: get_all_subscriptions
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5083,24 +5084,24 @@ paths:
   /api/requests:
     get:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Get a list of base resources with pagination
-      operationId: getAll_3
+      operationId: get_base_resources_3
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5117,30 +5118,30 @@ paths:
   /api/requests/{id}/subscriptions:
     get:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Get all children of a base resource with pagination
-      operationId: getResource_3
+      operationId: get_children_base_resource_3
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5157,30 +5158,30 @@ paths:
   /api/requests/{id}/contracts:
     get:
       tags:
-      - Requested Resources
+        - Requested Resources
       summary: Get all children of a base resource with pagination
-      operationId: getResource_5
+      operationId: get_children_base_resource_5
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5197,30 +5198,30 @@ paths:
   /api/representations/{id}/subscriptions:
     get:
       tags:
-      - Representations
+        - Representations
       summary: Get all children of a base resource with pagination
-      operationId: getResource_7
+      operationId: get_children_base_resource_7
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5237,30 +5238,30 @@ paths:
   /api/offers/{id}/subscriptions:
     get:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Get all children of a base resource with pagination
-      operationId: getResource_11
+      operationId: get_children_base_resource_11
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5277,30 +5278,30 @@ paths:
   /api/offers/{id}/brokers:
     get:
       tags:
-      - Offered Resources
+        - Offered Resources
       summary: Get all children of a base resource with pagination
-      operationId: getResource_15
+      operationId: get_children_base_resource_15
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5317,30 +5318,30 @@ paths:
   /api/contracts/{id}/requests:
     get:
       tags:
-      - Contracts
+        - Contracts
       summary: Get all children of a base resource with pagination
-      operationId: getResource_17
+      operationId: get_children_base_resource_17
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5357,9 +5358,9 @@ paths:
   /api/connector:
     get:
       tags:
-      - Connector
+        - Connector
       summary: Private IDS self-description
-      operationId: getPrivateSelfDescription
+      operationId: get_private_selfdescription
       responses:
         "401":
           description: Unauthorized
@@ -5382,9 +5383,9 @@ paths:
   /api/configurations/active:
     get:
       tags:
-      - Configurations
+        - Configurations
       summary: Get current configuration
-      operationId: getConfiguration
+      operationId: get_active_config
       responses:
         "401":
           description: Unauthorized
@@ -5401,30 +5402,30 @@ paths:
   /api/brokers/{id}/offers:
     get:
       tags:
-      - Brokers
+        - Brokers
       summary: Get all children of a base resource with pagination
-      operationId: getResource_20
+      operationId: get_children_base_resource_20
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5441,30 +5442,30 @@ paths:
   /api/artifacts/{id}/subscriptions:
     get:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Get all children of a base resource with pagination
-      operationId: getResource_21
+      operationId: get_children_base_resource_21
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5481,27 +5482,27 @@ paths:
   /api/artifacts/{id}/data/**:
     get:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Get data by artifact id with query input
-      operationId: getData_1
+      operationId: get_data_by_artifact_id_1
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: download
-        in: query
-        required: false
-        schema:
-          type: boolean
-      - name: agreementUri
-        in: query
-        required: false
-        schema:
-          type: string
-          format: uri
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: download
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: agreementUri
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uri
       responses:
         "401":
           description: Unauthorized
@@ -5518,30 +5519,30 @@ paths:
   /api/artifacts/{id}/agreements:
     get:
       tags:
-      - Artifacts
+        - Artifacts
       summary: Get all children of a base resource with pagination
-      operationId: getResource_23
+      operationId: get_children_base_resource_23
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5558,30 +5559,30 @@ paths:
   /api/appstores/{id}/apps:
     get:
       tags:
-      - App Stores
+        - App Stores
       summary: Get all children of a base resource with pagination
-      operationId: getResource_24
+      operationId: get_children_base_resource_24
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5598,24 +5599,24 @@ paths:
   /api/apps:
     get:
       tags:
-      - Apps
+        - Apps
       summary: Get a list of base resources with pagination
-      operationId: getAll_14
+      operationId: get_base_resources_14
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5632,16 +5633,16 @@ paths:
   /api/apps/{id}:
     get:
       tags:
-      - Apps
+        - Apps
       summary: Get a base resource by id
-      operationId: get_14
+      operationId: get_base_resource_by_id_14
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -5657,16 +5658,16 @@ paths:
                 $ref: '#/components/schemas/AppView'
     delete:
       tags:
-      - Apps
+        - Apps
       summary: Delete a base resource by id
-      operationId: delete_14
+      operationId: delete_base_resource_by_id_14
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -5675,30 +5676,30 @@ paths:
   /api/apps/{id}/endpoints:
     get:
       tags:
-      - Apps
+        - Apps
       summary: Get all children of a base resource with pagination
-      operationId: getResource_25
+      operationId: get_children_base_resource_25
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5715,17 +5716,17 @@ paths:
   /api/apps/{id}/appstore:
     get:
       tags:
-      - Apps
+        - Apps
       summary: Get appstore by app id
       description: Get appstore holding this app.
-      operationId: relatedAppStore
+      operationId: get_appstore_by_app_id
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -5754,24 +5755,24 @@ paths:
   /api/agreements:
     get:
       tags:
-      - Agreements
+        - Agreements
       summary: Get a list of base resources with pagination
-      operationId: getAll_15
+      operationId: get_base_resources_15
       parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5788,16 +5789,16 @@ paths:
   /api/agreements/{id}:
     get:
       tags:
-      - Agreements
+        - Agreements
       summary: Get a base resource by id
-      operationId: get_15
+      operationId: get_base_resource_by_id_15
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
         "401":
           description: Unauthorized
@@ -5814,30 +5815,30 @@ paths:
   /api/agreements/{id}/artifacts:
     get:
       tags:
-      - Agreements
+        - Agreements
       summary: Get all children of a base resource with pagination
-      operationId: getResource_26
+      operationId: get_children_base_resource_26
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 30
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 30
       responses:
         "401":
           description: Unauthorized
@@ -5854,9 +5855,9 @@ paths:
   /:
     get:
       tags:
-      - Connector
+        - Connector
       summary: Public IDS self-description
-      operationId: getPublicSelfDescription_1
+      operationId: get_public_selfdescription_1_1
       responses:
         "401":
           description: Unauthorized
@@ -5976,8 +5977,8 @@ components:
         deploy:
           type: string
           enum:
-          - None
-          - Camel
+            - None
+            - Camel
     Endpoint:
       type: object
       properties:
@@ -6027,8 +6028,8 @@ components:
         deploy:
           type: string
           enum:
-          - None
-          - Camel
+            - None
+            - Camel
         start:
           $ref: '#/components/schemas/Endpoint'
         end:
@@ -6076,10 +6077,10 @@ components:
         paymentMethod:
           type: string
           enum:
-          - undefined
-          - fixedPrice
-          - free
-          - negotiationBasis
+            - undefined
+            - fixedPrice
+            - free
+            - negotiationBasis
     RequestedResourceView:
       type: object
       properties:
@@ -6120,10 +6121,10 @@ components:
         paymentModality:
           type: string
           enum:
-          - undefined
-          - fixedPrice
-          - free
-          - negotiationBasis
+            - undefined
+            - fixedPrice
+            - free
+            - negotiationBasis
         samples:
           type: array
           items:
@@ -6211,10 +6212,10 @@ components:
         paymentMethod:
           type: string
           enum:
-          - undefined
-          - fixedPrice
-          - free
-          - negotiationBasis
+            - undefined
+            - fixedPrice
+            - free
+            - negotiationBasis
     OfferedResourceView:
       type: object
       properties:
@@ -6252,10 +6253,10 @@ components:
         paymentModality:
           type: string
           enum:
-          - undefined
-          - fixedPrice
-          - free
-          - negotiationBasis
+            - undefined
+            - fixedPrice
+            - free
+            - negotiationBasis
         samples:
           type: array
           items:
@@ -6270,27 +6271,27 @@ components:
     AppEndpointDesc:
       type: object
       allOf:
-      - $ref: '#/components/schemas/EndpointDesc'
-      - type: object
-        properties:
-          endpointType:
-            type: string
-          endpointPort:
-            type: integer
-            format: int32
-          mediaType:
-            type: string
-          protocol:
-            type: string
-          language:
-            type: string
+        - $ref: '#/components/schemas/EndpointDesc'
+        - type: object
+          properties:
+            endpointType:
+              type: string
+            endpointPort:
+              type: integer
+              format: int32
+            mediaType:
+              type: string
+            protocol:
+              type: string
+            language:
+              type: string
     ConnectorEndpointDesc:
       type: object
       allOf:
-      - $ref: '#/components/schemas/EndpointDesc'
+        - $ref: '#/components/schemas/EndpointDesc'
     EndpointDesc:
       required:
-      - type
+        - type
       type: object
       properties:
         location:
@@ -6308,7 +6309,7 @@ components:
     GenericEndpointDesc:
       type: object
       allOf:
-      - $ref: '#/components/schemas/EndpointDesc'
+        - $ref: '#/components/schemas/EndpointDesc'
     AuthenticationDesc:
       type: object
       properties:
@@ -6324,8 +6325,8 @@ components:
         type:
           type: string
           enum:
-          - Database
-          - REST
+            - Database
+            - REST
     DataSourceView:
       type: object
       properties:
@@ -6341,8 +6342,8 @@ components:
         type:
           type: string
           enum:
-          - Database
-          - REST
+            - Database
+            - REST
         _links:
           $ref: '#/components/schemas/Links'
     ContractDesc:
@@ -6431,29 +6432,29 @@ components:
           type: string
           readOnly: true
           enum:
-          - Base Security
-          - Trust Plus Security
-          - Trust Security
+            - Base Security
+            - Trust Plus Security
+            - Trust Security
         logLevel:
           type: string
           enum:
-          - "Off"
-          - Trace
-          - Debug
-          - Info
-          - Warn
-          - Error
+            - "Off"
+            - Trace
+            - Debug
+            - Info
+            - Warn
+            - Error
         status:
           type: string
           enum:
-          - Faulty
-          - Offline
-          - Online
+            - Faulty
+            - Offline
+            - Online
         deployMode:
           type: string
           enum:
-          - Productive
-          - Test
+            - Productive
+            - Test
         truststoreSettings:
           $ref: '#/components/schemas/TruststoreDesc'
         proxySettings:
@@ -6528,29 +6529,29 @@ components:
         securityProfile:
           type: string
           enum:
-          - Base Security
-          - Trust Plus Security
-          - Trust Security
+            - Base Security
+            - Trust Plus Security
+            - Trust Security
         status:
           type: string
           enum:
-          - Faulty
-          - Offline
-          - Online
+            - Faulty
+            - Offline
+            - Online
         logLevel:
           type: string
           enum:
-          - "Off"
-          - Trace
-          - Debug
-          - Info
-          - Warn
-          - Error
+            - "Off"
+            - Trace
+            - Debug
+            - Info
+            - Warn
+            - Error
         deployMode:
           type: string
           enum:
-          - Productive
-          - Test
+            - Productive
+            - Test
         proxy:
           $ref: '#/components/schemas/ProxyView'
         trustStore:
@@ -6633,8 +6634,8 @@ components:
           type: string
           readOnly: true
           enum:
-          - Unregistered
-          - Registered
+            - Unregistered
+            - Registered
     BrokerView:
       type: object
       properties:
@@ -6654,8 +6655,8 @@ components:
         status:
           type: string
           enum:
-          - Unregistered
-          - Registered
+            - Unregistered
+            - Registered
         _links:
           $ref: '#/components/schemas/Links'
     ArtifactDesc:
@@ -6858,19 +6859,19 @@ components:
           $ref: '#/components/schemas/PageMetadata'
     AbstractConstraint:
       required:
-      - '@id'
-      - '@type'
+        - '@id'
+        - '@type'
       type: object
       properties:
         properties:
           type: object
           additionalProperties:
             type: object
-        label:
+        comment:
           type: array
           items:
             $ref: '#/components/schemas/TypedLiteral'
-        comment:
+        label:
           type: array
           items:
             $ref: '#/components/schemas/TypedLiteral'
@@ -6883,174 +6884,174 @@ components:
         propertyName: '@type'
     Constraint:
       required:
-      - '@id'
-      - '@type'
-      - ids:leftOperand
-      - ids:operator
+        - '@id'
+        - '@type'
+        - ids:leftOperand
+        - ids:operator
       type: object
       discriminator:
         propertyName: '@type'
       allOf:
-      - $ref: '#/components/schemas/AbstractConstraint'
-      - type: object
-        properties:
-          ids:unit:
-            type: string
-            format: uri
-          ids:operator:
-            type: string
-            enum:
-            - https://w3id.org/idsa/code/AFTER
-            - https://w3id.org/idsa/code/BEFORE
-            - https://w3id.org/idsa/code/CONTAINS
-            - https://w3id.org/idsa/code/COVERED_BY
-            - https://w3id.org/idsa/code/COVERS
-            - https://w3id.org/idsa/code/DEFINES_AS
-            - https://w3id.org/idsa/code/DISJOINT
-            - https://w3id.org/idsa/code/DURATION_EQ
-            - https://w3id.org/idsa/code/DURING
-            - https://w3id.org/idsa/code/EQ
-            - https://w3id.org/idsa/code/EQUALS
-            - https://w3id.org/idsa/code/FINISHED_BY
-            - https://w3id.org/idsa/code/FINISHES
-            - https://w3id.org/idsa/code/GT
-            - https://w3id.org/idsa/code/GTEQ
-            - https://w3id.org/idsa/code/HAS_MEMBERSHIP
-            - https://w3id.org/idsa/code/HAS_SITE
-            - https://w3id.org/idsa/code/HAS_STATE
-            - https://w3id.org/idsa/code/IN
-            - https://w3id.org/idsa/code/INSIDE
-            - https://w3id.org/idsa/code/INSIDE_NETWORK
-            - https://w3id.org/idsa/code/LONGER
-            - https://w3id.org/idsa/code/LONGER_EQ
-            - https://w3id.org/idsa/code/LT
-            - https://w3id.org/idsa/code/LTEQ
-            - https://w3id.org/idsa/code/MATCHES
-            - https://w3id.org/idsa/code/MEETS
-            - https://w3id.org/idsa/code/MEMBER_OF
-            - https://w3id.org/idsa/code/MET_BY
-            - https://w3id.org/idsa/code/NOT
-            - https://w3id.org/idsa/code/OVERLAPPED_BY
-            - https://w3id.org/idsa/code/OVERLAPS
-            - https://w3id.org/idsa/code/SAME_AS
-            - https://w3id.org/idsa/code/SHORTER
-            - https://w3id.org/idsa/code/SHORTER_EQ
-            - https://w3id.org/idsa/code/SPATIAL_CONTAINS
-            - https://w3id.org/idsa/code/SPATIAL_EQUALS
-            - https://w3id.org/idsa/code/SPATIAL_MEET
-            - https://w3id.org/idsa/code/SPATIAL_OVERLAP
-            - https://w3id.org/idsa/code/STARTED_BY
-            - https://w3id.org/idsa/code/STARTS
-            - https://w3id.org/idsa/code/STRING_CONTAINS
-            - https://w3id.org/idsa/code/STRING_EQ
-            - https://w3id.org/idsa/code/STRING_IS_CONTAINED
-            - https://w3id.org/idsa/code/TEMPORAL_DISJOINT
-            - https://w3id.org/idsa/code/TEMPORAL_EQUALS
-          ids:leftOperand:
-            type: string
-            enum:
-            - https://w3id.org/idsa/code/ABSOLUTE_SPATIAL_POSITION
-            - https://w3id.org/idsa/code/COUNT
-            - https://w3id.org/idsa/code/DELAY
-            - https://w3id.org/idsa/code/ELAPSED_TIME
-            - https://w3id.org/idsa/code/ENDPOINT
-            - https://w3id.org/idsa/code/EVENT
-            - https://w3id.org/idsa/code/PATH
-            - https://w3id.org/idsa/code/PAYMENT
-            - https://w3id.org/idsa/code/PAY_AMOUNT
-            - https://w3id.org/idsa/code/POLICY_EVALUATION_TIME
-            - https://w3id.org/idsa/code/PURPOSE
-            - https://w3id.org/idsa/code/QUANTITY
-            - https://w3id.org/idsa/code/RECURRENCE_RATE
-            - https://w3id.org/idsa/code/SECURITY_LEVEL
-            - https://w3id.org/idsa/code/STATE
-            - https://w3id.org/idsa/code/SYSTEM
-            - https://w3id.org/idsa/code/USER
-          ids:rightOperand:
-            $ref: '#/components/schemas/RdfResource'
-          ids:pipEndpoint:
-            type: string
-            format: uri
-          ids:rightOperandReference:
-            type: string
-            format: uri
-          '@type':
-            type: string
+        - $ref: '#/components/schemas/AbstractConstraint'
+        - type: object
+          properties:
+            ids:operator:
+              type: string
+              enum:
+                - https://w3id.org/idsa/code/AFTER
+                - https://w3id.org/idsa/code/BEFORE
+                - https://w3id.org/idsa/code/CONTAINS
+                - https://w3id.org/idsa/code/COVERED_BY
+                - https://w3id.org/idsa/code/COVERS
+                - https://w3id.org/idsa/code/DEFINES_AS
+                - https://w3id.org/idsa/code/DISJOINT
+                - https://w3id.org/idsa/code/DURATION_EQ
+                - https://w3id.org/idsa/code/DURING
+                - https://w3id.org/idsa/code/EQ
+                - https://w3id.org/idsa/code/EQUALS
+                - https://w3id.org/idsa/code/FINISHED_BY
+                - https://w3id.org/idsa/code/FINISHES
+                - https://w3id.org/idsa/code/GT
+                - https://w3id.org/idsa/code/GTEQ
+                - https://w3id.org/idsa/code/HAS_MEMBERSHIP
+                - https://w3id.org/idsa/code/HAS_SITE
+                - https://w3id.org/idsa/code/HAS_STATE
+                - https://w3id.org/idsa/code/IN
+                - https://w3id.org/idsa/code/INSIDE
+                - https://w3id.org/idsa/code/INSIDE_NETWORK
+                - https://w3id.org/idsa/code/LONGER
+                - https://w3id.org/idsa/code/LONGER_EQ
+                - https://w3id.org/idsa/code/LT
+                - https://w3id.org/idsa/code/LTEQ
+                - https://w3id.org/idsa/code/MATCHES
+                - https://w3id.org/idsa/code/MEETS
+                - https://w3id.org/idsa/code/MEMBER_OF
+                - https://w3id.org/idsa/code/MET_BY
+                - https://w3id.org/idsa/code/NOT
+                - https://w3id.org/idsa/code/OVERLAPPED_BY
+                - https://w3id.org/idsa/code/OVERLAPS
+                - https://w3id.org/idsa/code/SAME_AS
+                - https://w3id.org/idsa/code/SHORTER
+                - https://w3id.org/idsa/code/SHORTER_EQ
+                - https://w3id.org/idsa/code/SPATIAL_CONTAINS
+                - https://w3id.org/idsa/code/SPATIAL_EQUALS
+                - https://w3id.org/idsa/code/SPATIAL_MEET
+                - https://w3id.org/idsa/code/SPATIAL_OVERLAP
+                - https://w3id.org/idsa/code/STARTED_BY
+                - https://w3id.org/idsa/code/STARTS
+                - https://w3id.org/idsa/code/STRING_CONTAINS
+                - https://w3id.org/idsa/code/STRING_EQ
+                - https://w3id.org/idsa/code/STRING_IS_CONTAINED
+                - https://w3id.org/idsa/code/TEMPORAL_DISJOINT
+                - https://w3id.org/idsa/code/TEMPORAL_EQUALS
+            ids:rightOperand:
+              $ref: '#/components/schemas/RdfResource'
+            ids:unit:
+              type: string
+              format: uri
+            ids:leftOperand:
+              type: string
+              enum:
+                - https://w3id.org/idsa/code/ABSOLUTE_SPATIAL_POSITION
+                - https://w3id.org/idsa/code/COUNT
+                - https://w3id.org/idsa/code/DELAY
+                - https://w3id.org/idsa/code/ELAPSED_TIME
+                - https://w3id.org/idsa/code/ENDPOINT
+                - https://w3id.org/idsa/code/EVENT
+                - https://w3id.org/idsa/code/PATH
+                - https://w3id.org/idsa/code/PAYMENT
+                - https://w3id.org/idsa/code/PAY_AMOUNT
+                - https://w3id.org/idsa/code/POLICY_EVALUATION_TIME
+                - https://w3id.org/idsa/code/PURPOSE
+                - https://w3id.org/idsa/code/QUANTITY
+                - https://w3id.org/idsa/code/RECURRENCE_RATE
+                - https://w3id.org/idsa/code/SECURITY_LEVEL
+                - https://w3id.org/idsa/code/STATE
+                - https://w3id.org/idsa/code/SYSTEM
+                - https://w3id.org/idsa/code/USER
+            ids:pipEndpoint:
+              type: string
+              format: uri
+            ids:rightOperandReference:
+              type: string
+              format: uri
+            '@type':
+              type: string
     Duty:
       required:
-      - '@id'
-      - '@type'
-      - ids:action
+        - '@id'
+        - '@type'
+        - ids:action
       type: object
       discriminator:
         propertyName: '@type'
       allOf:
-      - $ref: '#/components/schemas/Rule'
-      - type: object
-        properties:
-          '@type':
-            type: string
+        - $ref: '#/components/schemas/Rule'
+        - type: object
+          properties:
+            '@type':
+              type: string
     LogicalConstraint:
       required:
-      - '@id'
-      - '@type'
+        - '@id'
+        - '@type'
       type: object
       discriminator:
         propertyName: '@type'
       allOf:
-      - $ref: '#/components/schemas/AbstractConstraint'
-      - type: object
-        properties:
-          ids:and:
-            type: array
-            items:
-              $ref: '#/components/schemas/Constraint'
-          ids:or:
-            type: array
-            items:
-              $ref: '#/components/schemas/Constraint'
-          ids:xone:
-            type: array
-            items:
-              $ref: '#/components/schemas/Constraint'
-          '@type':
-            type: string
+        - $ref: '#/components/schemas/AbstractConstraint'
+        - type: object
+          properties:
+            ids:or:
+              type: array
+              items:
+                $ref: '#/components/schemas/Constraint'
+            ids:xone:
+              type: array
+              items:
+                $ref: '#/components/schemas/Constraint'
+            ids:and:
+              type: array
+              items:
+                $ref: '#/components/schemas/Constraint'
+            '@type':
+              type: string
     Permission:
       required:
-      - '@id'
-      - '@type'
-      - ids:action
+        - '@id'
+        - '@type'
+        - ids:action
       type: object
       discriminator:
         propertyName: '@type'
       allOf:
-      - $ref: '#/components/schemas/Rule'
-      - type: object
-        properties:
-          ids:postDuty:
-            type: array
-            items:
-              $ref: '#/components/schemas/Duty'
-          ids:preDuty:
-            type: array
-            items:
-              $ref: '#/components/schemas/Duty'
-          '@type':
-            type: string
+        - $ref: '#/components/schemas/Rule'
+        - type: object
+          properties:
+            ids:preDuty:
+              type: array
+              items:
+                $ref: '#/components/schemas/Duty'
+            ids:postDuty:
+              type: array
+              items:
+                $ref: '#/components/schemas/Duty'
+            '@type':
+              type: string
     Prohibition:
       required:
-      - '@id'
-      - '@type'
-      - ids:action
+        - '@id'
+        - '@type'
+        - ids:action
       type: object
       discriminator:
         propertyName: '@type'
       allOf:
-      - $ref: '#/components/schemas/Rule'
-      - type: object
-        properties:
-          '@type':
-            type: string
+        - $ref: '#/components/schemas/Rule'
+        - type: object
+          properties:
+            '@type':
+              type: string
     RdfResource:
       type: object
       properties:
@@ -7060,37 +7061,32 @@ components:
           type: string
     Rule:
       required:
-      - '@id'
-      - '@type'
-      - ids:action
+        - '@id'
+        - '@type'
+        - ids:action
       type: object
       properties:
         properties:
           type: object
           additionalProperties:
             type: object
-        label:
+        comment:
           type: array
           items:
             $ref: '#/components/schemas/TypedLiteral'
-        comment:
+        label:
           type: array
           items:
             $ref: '#/components/schemas/TypedLiteral'
         ids:target:
           type: string
           format: uri
-        ids:constraint:
-          type: array
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/LogicalConstraint'
-        ids:assignee:
+        ids:assigner:
           type: array
           items:
             type: string
             format: uri
-        ids:assigner:
+        ids:assignee:
           type: array
           items:
             type: string
@@ -7100,26 +7096,31 @@ components:
           items:
             type: string
             enum:
-            - https://w3id.org/idsa/code/AGGREGATE_BY_CONSUMER
-            - https://w3id.org/idsa/code/AGGREGATE_BY_PROVIDER
-            - https://w3id.org/idsa/code/ANONYMIZE
-            - https://w3id.org/idsa/code/COMPENSATE
-            - https://w3id.org/idsa/code/DELETE
-            - https://w3id.org/idsa/code/DISTRIBUTE
-            - https://w3id.org/idsa/code/ENCRYPT
-            - https://w3id.org/idsa/code/GRANT_USE
-            - https://w3id.org/idsa/code/LOG
-            - https://w3id.org/idsa/code/MODIFY
-            - https://w3id.org/idsa/code/NEXT_POLICY
-            - https://w3id.org/idsa/code/NOTIFY
-            - https://w3id.org/idsa/code/READ
-            - https://w3id.org/idsa/code/TRACK_PROVENANCE
-            - https://w3id.org/idsa/code/USE
-            - https://w3id.org/idsa/code/WRITE
+              - https://w3id.org/idsa/code/AGGREGATE_BY_CONSUMER
+              - https://w3id.org/idsa/code/AGGREGATE_BY_PROVIDER
+              - https://w3id.org/idsa/code/ANONYMIZE
+              - https://w3id.org/idsa/code/COMPENSATE
+              - https://w3id.org/idsa/code/DELETE
+              - https://w3id.org/idsa/code/DISTRIBUTE
+              - https://w3id.org/idsa/code/ENCRYPT
+              - https://w3id.org/idsa/code/GRANT_USE
+              - https://w3id.org/idsa/code/LOG
+              - https://w3id.org/idsa/code/MODIFY
+              - https://w3id.org/idsa/code/NEXT_POLICY
+              - https://w3id.org/idsa/code/NOTIFY
+              - https://w3id.org/idsa/code/READ
+              - https://w3id.org/idsa/code/TRACK_PROVENANCE
+              - https://w3id.org/idsa/code/USE
+              - https://w3id.org/idsa/code/WRITE
+        ids:constraint:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/LogicalConstraint'
         ids:assetRefinement:
           oneOf:
-          - $ref: '#/components/schemas/Constraint'
-          - $ref: '#/components/schemas/LogicalConstraint'
+            - $ref: '#/components/schemas/Constraint'
+            - $ref: '#/components/schemas/LogicalConstraint'
         ids:description:
           type: array
           items:
@@ -7150,11 +7151,11 @@ components:
         type: CONNECTOR_RESTRICTED_USAGE
         url: https://localhost:8080
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
-      - type: object
-        properties:
-          url:
-            type: string
+        - $ref: '#/components/schemas/PatternDesc'
+        - type: object
+          properties:
+            url:
+              type: string
     DeletionDesc:
       type: object
       example:
@@ -7163,26 +7164,26 @@ components:
         end: 2020-07-11T00:00:00Z
         date: 2020-07-11T00:00:00Z
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
-      - type: object
-        properties:
-          start:
-            type: string
-          end:
-            type: string
-          date:
-            type: string
+        - $ref: '#/components/schemas/PatternDesc'
+        - type: object
+          properties:
+            start:
+              type: string
+            end:
+              type: string
+            date:
+              type: string
     DurationDesc:
       type: object
       example:
         type: DURATION_USAGE
         duration: PT1M30.5S
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
-      - type: object
-        properties:
-          duration:
-            type: string
+        - $ref: '#/components/schemas/PatternDesc'
+        - type: object
+          properties:
+            duration:
+              type: string
     IntervalDesc:
       type: object
       example:
@@ -7190,33 +7191,33 @@ components:
         start: 2020-07-11T00:00:00Z
         end: 2020-07-11T00:00:00Z
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
-      - type: object
-        properties:
-          start:
-            type: string
-          end:
-            type: string
+        - $ref: '#/components/schemas/PatternDesc'
+        - type: object
+          properties:
+            start:
+              type: string
+            end:
+              type: string
     LoggingDesc:
       type: object
       example:
         type: USAGE_LOGGING
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
+        - $ref: '#/components/schemas/PatternDesc'
     NotificationDesc:
       type: object
       example:
         type: USAGE_NOTIFICATION
         url: https://localhost:8080/api/ids/data
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
-      - type: object
-        properties:
-          url:
-            type: string
+        - $ref: '#/components/schemas/PatternDesc'
+        - type: object
+          properties:
+            url:
+              type: string
     PatternDesc:
       required:
-      - type
+        - type
       type: object
       properties:
         title:
@@ -7232,13 +7233,13 @@ components:
       example:
         type: PROVIDE_ACCESS
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
+        - $ref: '#/components/schemas/PatternDesc'
     ProhibitionDesc:
       type: object
       example:
         type: PROHIBIT_ACCESS
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
+        - $ref: '#/components/schemas/PatternDesc'
     SecurityRestrictionDesc:
       type: object
       description: "Possible profiles are: idsc:BASE_SECURITY_PROFILE, idsc:TRUST_SECURITY_PROFILE\
@@ -7247,22 +7248,22 @@ components:
         type: SECURITY_PROFILE_RESTRICTED_USAGE
         profile: BASE_SECURITY_PROFILE
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
-      - type: object
-        properties:
-          profile:
-            type: string
+        - $ref: '#/components/schemas/PatternDesc'
+        - type: object
+          properties:
+            profile:
+              type: string
     UsageNumberDesc:
       type: object
       example:
         type: N_TIMES_USAGE
         value: "5"
       allOf:
-      - $ref: '#/components/schemas/PatternDesc'
-      - type: object
-        properties:
-          value:
-            type: string
+        - $ref: '#/components/schemas/PatternDesc'
+        - type: object
+          properties:
+            value:
+              type: string
     PagedModelContractRuleView:
       type: object
       properties:
@@ -7421,16 +7422,16 @@ components:
           items:
             type: string
             enum:
-            - PROVIDE_ACCESS
-            - PROHIBIT_ACCESS
-            - N_TIMES_USAGE
-            - DURATION_USAGE
-            - USAGE_DURING_INTERVAL
-            - USAGE_UNTIL_DELETION
-            - USAGE_LOGGING
-            - USAGE_NOTIFICATION
-            - CONNECTOR_RESTRICTED_USAGE
-            - SECURITY_PROFILE_RESTRICTED_USAGE
+              - PROVIDE_ACCESS
+              - PROHIBIT_ACCESS
+              - N_TIMES_USAGE
+              - DURATION_USAGE
+              - USAGE_DURING_INTERVAL
+              - USAGE_UNTIL_DELETION
+              - USAGE_LOGGING
+              - USAGE_NOTIFICATION
+              - CONNECTOR_RESTRICTED_USAGE
+              - SECURITY_PROFILE_RESTRICTED_USAGE
         keywords:
           type: array
           items:
@@ -7480,9 +7481,9 @@ components:
         type:
           type: string
           enum:
-          - APP
-          - CONNECTOR
-          - GENERIC
+            - APP
+            - CONNECTOR
+            - GENERIC
         creationDate:
           type: string
           format: date-time
@@ -7541,3 +7542,4 @@ components:
           type: string
         templated:
           type: boolean
+

--- a/src/main/java/io/dataspaceconnector/controller/MainController.java
+++ b/src/main/java/io/dataspaceconnector/controller/MainController.java
@@ -69,7 +69,7 @@ public class MainController {
      * @return Self-description or error response.
      */
     @GetMapping(value = {"/", ""}, produces = "application/ld+json")
-    @Operation(summary = "Public IDS self-description")
+    @Operation(summary = "Public IDS self-description", operationId = "get_public_selfdescription")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,
@@ -85,7 +85,8 @@ public class MainController {
      * @return Self-description or error response.
      */
     @GetMapping(value = "/api/connector", produces = "application/ld+json")
-    @Operation(summary = "Private IDS self-description")
+    @Operation(summary = "Private IDS self-description",
+            operationId = "get_private_selfdescription")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,

--- a/src/main/java/io/dataspaceconnector/controller/gui/GuiController.java
+++ b/src/main/java/io/dataspaceconnector/controller/gui/GuiController.java
@@ -62,7 +62,7 @@ public class GuiController {
      */
     @Hidden
     @GetMapping(value = "/enum/{enumName}")
-    @Operation(summary = "Get the specific enum")
+    @Operation(summary = "Get the specific enum", operationId = "get_enum")
     @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK)
     @ApiResponse(responseCode = ResponseCode.BAD_REQUEST, description
             = ResponseDescription.BAD_REQUEST)

--- a/src/main/java/io/dataspaceconnector/controller/message/AppRequestController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/AppRequestController.java
@@ -94,7 +94,7 @@ public class AppRequestController {
      * @return Success, when app can be found and created from recipient response.
      */
     @PostMapping("/app")
-    @Operation(summary = "Download IDS app from AppStore")
+    @Operation(summary = "Download IDS app from AppStore", operationId = "post_download_ids_app")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "201", description = "Created"),

--- a/src/main/java/io/dataspaceconnector/controller/message/NotificationController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/NotificationController.java
@@ -68,7 +68,8 @@ public class NotificationController {
      */
     @PutMapping("/notify")
     @Operation(summary = "Notify all subscribers", description = "Can be used to manually notify "
-            + "all subscribers about a resource offer, representation, or artifact update.")
+            + "all subscribers about a resource offer, representation, or artifact update.",
+            operationId = "put_notify_subscribers")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "No Content"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/ConnectorUnavailableMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/ConnectorUnavailableMessageController.java
@@ -98,7 +98,8 @@ public class ConnectorUnavailableMessageController {
      */
     @PostMapping("/connector/unavailable")
     @Operation(summary = "Connector unavailable message", description = "Can be used for "
-            + "unregistering the connector at an IDS broker.")
+            + "unregistering the connector at an IDS broker.",
+            operationId = "post_send_connector_unavailable_message")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/ConnectorUpdateMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/ConnectorUpdateMessageController.java
@@ -98,7 +98,8 @@ public class ConnectorUpdateMessageController {
      */
     @PostMapping("/connector/update")
     @Operation(summary = "Connector update message", description = "Can be used for registering or "
-            + "updating the connector at an IDS broker.")
+            + "updating the connector at an IDS broker.",
+            operationId = "post_send_connector_update_message")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/ContractRequestMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/ContractRequestMessageController.java
@@ -126,7 +126,8 @@ public class ContractRequestMessageController {
      * @return The response entity.
      */
     @PostMapping("/contract")
-    @Operation(summary = "Send IDS contract request message")
+    @Operation(summary = "Send IDS contract request message",
+            operationId = "post_send_contract_request_message")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "201", description = "Created"),

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/DescriptionRequestMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/DescriptionRequestMessageController.java
@@ -90,7 +90,8 @@ public class DescriptionRequestMessageController {
      * @return The response entity.
      */
     @PostMapping("/description")
-    @Operation(summary = "Send IDS description request message")
+    @Operation(summary = "Send IDS description request message",
+            operationId = "post_send_description_request_message")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/QueryMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/QueryMessageController.java
@@ -94,7 +94,7 @@ public class QueryMessageController {
      */
     @PostMapping("/query")
     @Operation(summary = "Query message", description = "Can be used for querying an "
-            + "IDS component (e.g. the Broker).")
+            + "IDS component (e.g. the Broker).",  operationId = "post_send_query_message")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
@@ -157,7 +157,7 @@ public class QueryMessageController {
      */
     @PostMapping("/search")
     @Operation(summary = "Full text search", description = "Can be used for full text search at an "
-            + "IDS component (e.g. the Broker).")
+            + "IDS component (e.g. the Broker).", operationId = "post_send_full_text_query_message")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/ResourceUnavailableMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/ResourceUnavailableMessageController.java
@@ -98,7 +98,8 @@ public class ResourceUnavailableMessageController {
      */
     @PostMapping("/resource/unavailable")
     @Operation(summary = "Resource unavailable message", description = "Can be used for e.g. "
-            + "unregistering a resource at an IDS broker.")
+            + "unregistering a resource at an IDS broker.",
+            operationId = "post_send_resource_unavailable_message")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/ResourceUpdateMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/ResourceUpdateMessageController.java
@@ -98,7 +98,8 @@ public class ResourceUpdateMessageController {
      */
     @PostMapping("/resource/update")
     @Operation(summary = "Resource update message", description = "Can be used for registering "
-            + "or updating a resource at an IDS broker or consumer connector.")
+            + "or updating a resource at an IDS broker or consumer connector.",
+            operationId = "update_resource")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/SubscriptionMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/SubscriptionMessageController.java
@@ -82,7 +82,8 @@ public class SubscriptionMessageController {
      * @return The response entity.
      */
     @PostMapping("/subscribe")
-    @Operation(summary = "Send IDS request message for element subscription")
+    @Operation(summary = "Send IDS request message for element subscription",
+            operationId = "post_send_element_subscribe_message")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
@@ -133,7 +134,8 @@ public class SubscriptionMessageController {
      * @return The response entity.
      */
     @PostMapping("/unsubscribe")
-    @Operation(summary = "Send IDS request message for element unsubscription")
+    @Operation(summary = "Send IDS request message for element unsubscription",
+            operationId = "post_send_element_unsubscribe_message")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),

--- a/src/main/java/io/dataspaceconnector/controller/policy/ExampleController.java
+++ b/src/main/java/io/dataspaceconnector/controller/policy/ExampleController.java
@@ -67,7 +67,8 @@ public class ExampleController {
      * @return A pattern enum or error.
      */
     @Operation(summary = "Get pattern of policy",
-            description = "Get the policy pattern represented by a given JSON string.")
+            description = "Get the policy pattern represented by a given JSON string.",
+            operationId = "post_get_policy_pattern")
     @Tag(name = "Usage Control", description = "Endpoints for contract/policy handling")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
@@ -95,7 +96,8 @@ public class ExampleController {
      * @return An example policy object that can be filled out.
      */
     @Operation(summary = "Get example policy",
-            description = "Get an example policy for a given policy pattern.")
+            description = "Get an example policy for a given policy pattern.",
+            operationId = "post_get_example_policy")
     @Tag(name = "Usage Control", description = "Endpoints for contract/policy handling")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),

--- a/src/main/java/io/dataspaceconnector/controller/policy/SettingsController.java
+++ b/src/main/java/io/dataspaceconnector/controller/policy/SettingsController.java
@@ -56,7 +56,8 @@ public class SettingsController {
      * @return Http ok or error response.
      */
     @PutMapping(value = "/negotiation", produces = "application/json")
-    @Operation(summary = "Set contract negotiation status")
+    @Operation(summary = "Set contract negotiation status",
+            operationId = "put_contract_negotiation")
     @Tag(name = "Usage Control", description = "Endpoints for contract/policy handling")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
@@ -75,7 +76,8 @@ public class SettingsController {
      * @return Http ok or error response.
      */
     @GetMapping(value = "/negotiation", produces = "application/json")
-    @Operation(summary = "Get contract negotiation status")
+    @Operation(summary = "Get contract negotiation status",
+            operationId = "get_contract_negotiation")
     @Tag(name = "Usage Control", description = "Endpoints for contract/policy handling")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
@@ -100,7 +102,8 @@ public class SettingsController {
      */
     @PutMapping(value = "/pattern", produces = "application/json")
     @Operation(summary = "Allow unsupported patterns", description = "Allow "
-            + "requesting data without policy enforcement if an unsupported pattern is recognized.")
+            + "requesting data without policy enforcement if an unsupported pattern is recognized.",
+            operationId = "put_pattern_status")
     @Tag(name = "Usage Control", description = "Endpoints for contract/policy handling")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
@@ -120,7 +123,8 @@ public class SettingsController {
      */
     @GetMapping(value = "/pattern", produces = "application/json")
     @Operation(summary = "Get pattern validation status",
-            description = "Return if unsupported patterns are ignored when requesting data.")
+            description = "Return if unsupported patterns are ignored when requesting data.",
+            operationId = "get_pattern_status")
     @Tag(name = "Usage Control", description = "Endpoints for contract/policy handling")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),

--- a/src/main/java/io/dataspaceconnector/controller/resource/base/BaseResourceChildController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/base/BaseResourceChildController.java
@@ -113,7 +113,8 @@ public class BaseResourceChildController<S extends RelationService<?, ?, ?, ?>,
      */
     @SuppressWarnings("unchecked")
     @RequestMapping(method = RequestMethod.GET)
-    @Operation(summary = "Get all children of a base resource with pagination")
+    @Operation(summary = "Get all children of a base resource with pagination",
+            operationId = "get_children_base_resource")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,
@@ -143,7 +144,8 @@ public class BaseResourceChildController<S extends RelationService<?, ?, ?, ?>,
      * @return Response with code 200 (Ok) and the new children's list.
      */
     @PostMapping
-    @Operation(summary = "Add a list of children to a base resource")
+    @Operation(summary = "Add a list of children to a base resource",
+            operationId = "post_children_base_resource")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,
@@ -168,7 +170,8 @@ public class BaseResourceChildController<S extends RelationService<?, ?, ?, ?>,
      * @return Response with code 204 (No_Content).
      */
     @PutMapping
-    @Operation(summary = "Replace the children of a base resource")
+    @Operation(summary = "Replace the children of a base resource",
+            operationId = "put_children_base_resource")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
                     description = ResponseDescription.NO_CONTENT),
@@ -188,7 +191,8 @@ public class BaseResourceChildController<S extends RelationService<?, ?, ?, ?>,
      * @return Response with code 204 (No_Content).
      */
     @DeleteMapping
-    @Operation(summary = "Remove a list of children from a base resource")
+    @Operation(summary = "Remove a list of children from a base resource",
+            operationId = "delete_children_base_resource")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
                     description = ResponseDescription.NO_CONTENT),

--- a/src/main/java/io/dataspaceconnector/controller/resource/base/CRUDController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/base/CRUDController.java
@@ -53,7 +53,7 @@ public interface CRUDController<T extends Entity, D extends Description, V> {
      * @throws IllegalArgumentException if the description is null.
      */
     @PostMapping
-    @Operation(summary = "Create a base resource")
+    @Operation(summary = "Create a base resource", operationId = "post_base_resource")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.CREATED,
                     description = ResponseDescription.CREATED),
@@ -70,7 +70,8 @@ public interface CRUDController<T extends Entity, D extends Description, V> {
      * @return Response with code 200 (Ok) and the list of all endpoints of this resource type.
      */
     @RequestMapping(method = RequestMethod.GET)
-    @Operation(summary = "Get a list of base resources with pagination")
+    @Operation(summary = "Get a list of base resources with pagination",
+            operationId = "get_base_resources")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,
@@ -89,7 +90,7 @@ public interface CRUDController<T extends Entity, D extends Description, V> {
      * unknown.
      */
     @RequestMapping(value = "{id}", method = RequestMethod.GET)
-    @Operation(summary = "Get a base resource by id")
+    @Operation(summary = "Get a base resource by id",  operationId = "get_base_resource_by_id")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,
@@ -109,7 +110,7 @@ public interface CRUDController<T extends Entity, D extends Description, V> {
      * unknown.
      */
     @PutMapping("{id}")
-    @Operation(summary = "Update a base resource by id")
+    @Operation(summary = "Update a base resource by id",  operationId = "put_base_resource_by_id")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.CREATED,
                     description = ResponseDescription.CREATED),
@@ -128,7 +129,8 @@ public interface CRUDController<T extends Entity, D extends Description, V> {
      * @throws IllegalArgumentException if the resourceId is null.
      */
     @DeleteMapping("{id}")
-    @Operation(summary = "Delete a base resource by id")
+    @Operation(summary = "Delete a base resource by id",
+            operationId = "delete_base_resource_by_id")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
                     description = ResponseDescription.NO_CONTENT),

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/AppController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/AppController.java
@@ -101,7 +101,8 @@ public class AppController extends BaseResourceController<App, AppDesc, AppView,
      */
     @SuppressFBWarnings("IMPROPER_UNICODE")
     @PutMapping("/{id}/actions")
-    @Operation(summary = "Actions on apps", description = "Can be used for managing apps.")
+    @Operation(summary = "Actions on apps", description = "Can be used for managing apps.",
+            operationId = "put_app_action")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.BAD_REQUEST,
@@ -234,7 +235,8 @@ public class AppController extends BaseResourceController<App, AppDesc, AppView,
      * @return The app store.
      */
     @GetMapping("/{id}/appstore")
-    @Operation(summary = "Get appstore by app id", description = "Get appstore holding this app.")
+    @Operation(summary = "Get appstore by app id", description = "Get appstore holding this app.",
+            operationId = "get_appstore_by_app_id")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.BAD_REQUEST,

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
@@ -110,7 +110,8 @@ public class ArtifactController extends BaseResourceNotificationController<Artif
      * @throws IOException if the data cannot be received.
      */
     @GetMapping("{id}/data/**")
-    @Operation(summary = "Get data by artifact id with query input")
+    @Operation(summary = "Get data by artifact id with query input",
+            operationId = "get_data_by_artifact_id_1")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,
@@ -164,7 +165,8 @@ public class ArtifactController extends BaseResourceNotificationController<Artif
      * @throws UnexpectedResponseException if the ids response message has been unexpected.
      */
     @PostMapping("{id}/data")
-    @Operation(summary = "Get data by artifact id with query input")
+    @Operation(summary = "Get data by artifact id with query input",
+            operationId = "get_data_by_artifact_id_2")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/ConfigurationController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/ConfigurationController.java
@@ -66,7 +66,7 @@ public class ConfigurationController extends BaseResourceController<Configuratio
      * @return Ok or error response.
      */
     @PutMapping(value = "/{id}/active", consumes = {"*/*"})
-    @Operation(summary = "Update current configuration")
+    @Operation(summary = "Update current configuration", operationId = "put_active_config")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
                     description = ResponseDescription.NO_CONTENT),
@@ -96,7 +96,7 @@ public class ConfigurationController extends BaseResourceController<Configuratio
      * @return The configuration object or an error.
      */
     @GetMapping(value = "/active", produces = "application/hal+json")
-    @Operation(summary = "Get current configuration")
+    @Operation(summary = "Get current configuration", operationId = "get_active_config")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
             @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/EndpointController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/EndpointController.java
@@ -174,7 +174,8 @@ public class EndpointController implements CRUDController<Endpoint, EndpointDesc
      * @return response status OK if data source is created at generic endpoint.
      */
     @PutMapping("{id}/datasource/{dataSourceId}")
-    @Operation(summary = "Creates start endpoint for the route")
+    @Operation(summary = "Creates start endpoint for the route",
+            operationId = "put_route_start_endpoint")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
                     description = ResponseDescription.NO_CONTENT),

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/RouteController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/RouteController.java
@@ -58,7 +58,8 @@ public class RouteController extends BaseResourceController<Route, RouteDesc, Ro
      * @return response status OK, if start endpoint is created.
      */
     @PutMapping("{id}/endpoint/start")
-    @Operation(summary = "Creates start endpoint for the route")
+    @Operation(summary = "Creates start endpoint for the route",
+            operationId = "put_route_start_endpoint")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
                     description = ResponseDescription.NO_CONTENT),
@@ -76,7 +77,8 @@ public class RouteController extends BaseResourceController<Route, RouteDesc, Ro
      * @return response status OK, if start endpoint is deleted.
      */
     @DeleteMapping("{id}/endpoint/start")
-    @Operation(summary = "Deletes the start endpoint of the route")
+    @Operation(summary = "Deletes the start endpoint of the route",
+            operationId = "delete_route_endpoint_start")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
                     description = ResponseDescription.NO_CONTENT),
@@ -94,7 +96,8 @@ public class RouteController extends BaseResourceController<Route, RouteDesc, Ro
      * @return response status OK, if last endpoint is created.
      */
     @PutMapping("{id}/endpoint/end")
-    @Operation(summary = "Creates last endpoint for the route")
+    @Operation(summary = "Creates last endpoint for the route",
+            operationId = "put_route_end_endpoint")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
                     description = ResponseDescription.NO_CONTENT),
@@ -112,7 +115,8 @@ public class RouteController extends BaseResourceController<Route, RouteDesc, Ro
      * @return response status OK, if last endpoint is deleted.
      */
     @DeleteMapping("{id}/endpoint/end")
-    @Operation(summary = "Deletes the start endpoint of the route")
+    @Operation(summary = "Deletes the last endpoint of the route",
+            operationId = "delete_route_end_endpoint")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
                     description = ResponseDescription.NO_CONTENT),

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/SubscriptionController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/SubscriptionController.java
@@ -66,7 +66,7 @@ public class SubscriptionController extends BaseResourceController<Subscription,
      */
     @Override
     @PostMapping
-    @Operation(summary = "Create a base resource")
+    @Operation(summary = "Create a base resource", operationId = "post_subscription")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.CREATED,
                     description = ResponseDescription.CREATED),
@@ -86,6 +86,7 @@ public class SubscriptionController extends BaseResourceController<Subscription,
      * @return Response with code 200 (Ok) and the list of all endpoints of this resource type.
      */
     @GetMapping("owning")
+    @Operation(summary = "get list of all subscriptions", operationId = "get_all_subscriptions")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.METHOD_NOT_ALLOWED,
                     description = ResponseDescription.METHOD_NOT_ALLOWED),

--- a/src/main/java/io/dataspaceconnector/controller/routing/BeansController.java
+++ b/src/main/java/io/dataspaceconnector/controller/routing/BeansController.java
@@ -71,7 +71,8 @@ public class BeansController {
      */
     @Hidden
     @PostMapping
-    @Operation(summary = "Add a bean to the application context.")
+    @Operation(summary = "Add a bean to the application context.",
+            operationId = "post_bean_to_context")
     @Tag(name = "Camel", description = "Endpoints for dynamically managing Camel routes.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
@@ -118,7 +119,8 @@ public class BeansController {
      */
     @Hidden
     @DeleteMapping("/{beanId}")
-    @Operation(summary = "Remove a bean from the application context.")
+    @Operation(summary = "Remove a bean from the application context.",
+            operationId = "delete_bean_from_context")
     @Tag(name = "Camel", description = "Endpoints for dynamically managing Camel routes.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),

--- a/src/main/java/io/dataspaceconnector/controller/routing/RoutesController.java
+++ b/src/main/java/io/dataspaceconnector/controller/routing/RoutesController.java
@@ -68,7 +68,7 @@ public class RoutesController {
      */
     @Hidden
     @PostMapping
-    @Operation(summary = "Add a route to the Camel context.")
+    @Operation(summary = "Add a route to the Camel context.", operationId = "post_route_to_camel")
     @Tag(name = "Camel", description = "Endpoints for dynamically managing Camel routes.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
@@ -124,7 +124,8 @@ public class RoutesController {
      */
     @Hidden
     @DeleteMapping("/{routeId}")
-    @Operation(summary = "Delete a route from the Camel context.")
+    @Operation(summary = "Delete a route from the Camel context.",
+            operationId = "delete_route_from_camel")
     @Tag(name = "Camel", description = "Endpoints for dynamically managing Camel routes.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),

--- a/src/main/java/io/dataspaceconnector/controller/routing/error/ErrorController.java
+++ b/src/main/java/io/dataspaceconnector/controller/routing/error/ErrorController.java
@@ -67,7 +67,7 @@ public class ErrorController {
      */
     @Hidden
     @GetMapping(value = "/route/error", produces = "application/ld+json")
-    @Operation(summary = "Get new route related errors")
+    @Operation(summary = "Get new route related errors", operationId = "get_error_routes")
     @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK)
     @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,
             description = ResponseDescription.UNAUTHORIZED)


### PR DESCRIPTION
PR adds readable operationIDs to OpenApi Descriptions (eg. `post_send_connector_update_message`). 
Currently a draft, because the Controllers generated by `BaseResourceChildController` still use generated operation ids.

`CRUDController` also inherits operation IDs (`get_base_resource_by_id_6`)