### PR TITLE
feat: increase description field length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [X.X.X] - XXXX-XX-XX
+
+### Changed
+- Increase description column length to 4096.
+
 ## [6.3.1] - 2021-10-05
 
 ### Fixed

--- a/src/main/java/io/dataspaceconnector/model/config/DatabaseConstants.java
+++ b/src/main/java/io/dataspaceconnector/model/config/DatabaseConstants.java
@@ -26,6 +26,11 @@ public final class DatabaseConstants {
     public static final int URI_COLUMN_LENGTH = 2048;
 
     /**
+     * The maximum length of database columns containing desctiptons.
+     */
+    public static final int DESCRIPTION_COLUMN_LENGTH = 4000;
+
+    /**
      * Private constructor.
      */
     private DatabaseConstants() { }

--- a/src/main/java/io/dataspaceconnector/model/config/DatabaseConstants.java
+++ b/src/main/java/io/dataspaceconnector/model/config/DatabaseConstants.java
@@ -26,7 +26,7 @@ public final class DatabaseConstants {
     public static final int URI_COLUMN_LENGTH = 2048;
 
     /**
-     * The maximum length of database columns containing desctiptons.
+     * The maximum length of database columns containing descriptions.
      */
     public static final int DESCRIPTION_COLUMN_LENGTH = 4000;
 

--- a/src/main/java/io/dataspaceconnector/model/config/DatabaseConstants.java
+++ b/src/main/java/io/dataspaceconnector/model/config/DatabaseConstants.java
@@ -28,7 +28,7 @@ public final class DatabaseConstants {
     /**
      * The maximum length of database columns containing descriptions.
      */
-    public static final int DESCRIPTION_COLUMN_LENGTH = 4000;
+    public static final int DESCRIPTION_COLUMN_LENGTH = 4096;
 
     /**
      * Private constructor.

--- a/src/main/java/io/dataspaceconnector/model/named/NamedEntity.java
+++ b/src/main/java/io/dataspaceconnector/model/named/NamedEntity.java
@@ -21,6 +21,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 
 /**
@@ -43,5 +44,6 @@ public class NamedEntity extends Entity {
     /**
      * The description of the entity.
      */
+    @Column(length = 4000)
     private String description;
 }

--- a/src/main/java/io/dataspaceconnector/model/named/NamedEntity.java
+++ b/src/main/java/io/dataspaceconnector/model/named/NamedEntity.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
+import io.dataspaceconnector.model.config.DatabaseConstants;
 
 /**
  * The entity class which holds additional information like title, description.
@@ -44,6 +45,6 @@ public class NamedEntity extends Entity {
     /**
      * The description of the entity.
      */
-    @Column(length = 4000)
+    @Column(length = DESCRIPTION_COLUMN_LENGTH)
     private String description;
 }

--- a/src/main/java/io/dataspaceconnector/model/named/NamedEntity.java
+++ b/src/main/java/io/dataspaceconnector/model/named/NamedEntity.java
@@ -23,7 +23,7 @@ import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
-import io.dataspaceconnector.model.config.DatabaseConstants;
+import static io.dataspaceconnector.model.config.DatabaseConstants.DESCRIPTION_COLUMN_LENGTH;
 
 /**
  * The entity class which holds additional information like title, description.


### PR DESCRIPTION
This pull request fixes the issue #619 by setting the field length to 4000.

There are other two options for fixing this issue:

Setting the field TYPE to TEXT: this option might have problems with field data type compatibility among different databases.

Another option is setting Field type to Lob but this also might generate incompatibility issues as mentioned here (https://stackoverflow.com/questions/15135905/columndefinition-text-for-all-types-of-databases).

