### PR TITLE
feat: enable `linux/amd64` and `linux/arm64` docker images using Docker buildx

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -36,6 +36,9 @@ jobs:
          TMP=$(echo "$TMP" | tr '[:upper:]' '[:lower:]')
          echo $TMP
          echo ::set-output name=BRANCH::$TMP
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       -
         name: Install SBoM generator
         run: |
@@ -78,7 +81,7 @@ jobs:
       -
        name: Build image
        run: |
-        docker build . -t $IMAGE:$BRANCH
+        docker buildx build --platform linux/arm64,linux/amd64 . -t $IMAGE:$BRANCH
         BOM="dataspace-connector-sbom.json"
         syft "${IMAGE}:${BRANCH}" -o spdx-json > "${BOM}"
        env:
@@ -99,8 +102,7 @@ jobs:
            # Its a version tag
            TMP=${TAG:1:${#TAG}}
            echo "Found a version tag"
-           docker tag $IMAGE:$BRANCH $IMAGE:latest
-           docker push $IMAGE:latest
+           docker buildx build --push --platform linux/arm64,linux/amd64 -t $IMAGE:latest
            oras push "${IMAGE}:latest-sbom" "${BOM}:application/json"
 
            echo "${COSIGN_KEY}" > /tmp/cosign.key
@@ -109,8 +111,7 @@ jobs:
            rm /tmp/cosign.key
          fi
          # Has tag
-         docker tag $IMAGE:$BRANCH $IMAGE:$TMP
-         docker push $IMAGE:$TMP
+         docker buildx build --push --platform linux/arm64,linux/amd64 -t $IMAGE:$TMP
          oras push "${IMAGE}:${TMP}-sbom" "${BOM}:application/json"
 
          echo "${COSIGN_KEY}" > /tmp/cosign.key
@@ -127,7 +128,7 @@ jobs:
       -
        name: Push branch image
        run: |
-         docker push $IMAGE:$BRANCH
+         docker buildx build --push --platform linux/arm64,linux/amd64 -t $IMAGE:$BRANCH
 
          BOM="dataspace-connector-sbom.json"
          oras push "${IMAGE}:${BRANCH}-sbom" "${BOM}:application/json"
@@ -171,6 +172,9 @@ jobs:
          TMP=$(echo "$TMP" | tr '[:upper:]' '[:lower:]')
          echo $TMP
          echo ::set-output name=BRANCH::$TMP
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       -
         name: Install SBoM generator
         run: |
@@ -213,7 +217,7 @@ jobs:
       -
        name: Build image
        run: |
-        docker build . -f scripts/ci/docker/Debug.dockerfile -t $IMAGE:$BRANCH
+        docker buildx build --platform linux/arm64,linux/amd64 . -f scripts/ci/docker/Debug.dockerfile -t $IMAGE:$BRANCH
         BOM="dataspace-connector-sbom.json"
         syft "${IMAGE}:${BRANCH}" -o spdx-json > "${BOM}"
        env:
@@ -236,8 +240,7 @@ jobs:
            echo "Found a version tag"
          fi
          # Has tag
-         docker tag $IMAGE:$BRANCH $IMAGE:$TMP-debug
-         docker push $IMAGE:$TMP-debug
+         docker buildx build --push --platform linux/arm64,linux/amd64 -t $IMAGE:$TMP-debug
          oras push "${IMAGE}:${TMP}-debug-sbom" "${BOM}:application/json"
 
          echo "${COSIGN_KEY}" > /tmp/cosign.key
@@ -254,8 +257,7 @@ jobs:
       -
        name: Push branch image
        run: |
-         docker tag $IMAGE:$BRANCH $IMAGE:$BRANCH-debug
-         docker push $IMAGE:$BRANCH-debug
+         docker buildx build --push --platform linux/arm64,linux/amd64 -t $IMAGE:$BRANCH-debug
          BOM="dataspace-connector-sbom.json"
          oras push "${IMAGE}:${BRANCH}-debug-sbom" "${BOM}:application/json"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,22 +8,12 @@ concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
+  OWNER: ${{ secrets.REPO_USER }}
+
 jobs:
-  setup:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      branch_name: ${{ steps.get_branch_name.outputs.HEAD_REF }}
-
-    steps:
-    - name: Build branch name
-      id: get_branch_name
-      run: |
-          HEAD_REF=$(echo "${GITHUB_HEAD_REF}" | sed 's_/_\-_g' )
-          echo ::set-output name=HEAD_REF::"${HEAD_REF}"
-
   style:
-    needs: [setup]
     timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
@@ -32,21 +22,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v1
       with:
-        distribution: 'temurin'
-        java-version: '11'
+       java-version: 11
     - name: Cache maven packages
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-style-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-style-
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Run style checks
-      run: mvn -B checkstyle:check --file pom.xml
+      run: mvn -B -U checkstyle:check --file pom.xml
 
   license:
-    needs: [setup]
     timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
@@ -55,89 +43,17 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v1
       with:
-        distribution: 'temurin'
-        java-version: '11'
+       java-version: 11
     - name: Cache maven packages
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-license-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-license-
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Run license checks
-      run: mvn -B license:check --file pom.xml
-
-  static-code-analysis:
-    needs: [setup, style, license]
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-analysis-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-analysis-
-    - name: Run static code analysis
-      run: mvn -B compile spotbugs:check --file pom.xml
-
-  unit-and-integration-tests:
-    needs: [setup, style, license]
-    timeout-minutes: 30
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [11]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java }}
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-m2-
-    - name: Unit- and Integrationtests
-      run: mvn -B -U verify --file pom.xml -Prelease
-
-  mutation-tests:
-    needs: [setup, unit-and-integration-tests]
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-${{ needs.setup.outputs.branch_name }}-m2-
-    - name: Run Mutation Tests
-      run: mvn -B -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml
+      run: mvn -B -U license:check --file pom.xml
 
   linting:
     timeout-minutes: 5
@@ -148,122 +64,185 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Lint Docker
-      uses: hadolint/hadolint-action@v1.6.0
+      uses: hadolint/hadolint-action@v1.5.0
       with:
         dockerfile: Dockerfile
         config: .hadolint.yaml
+    # - name: Lint Docker and Yaml
+    #   uses: bridgecrewio/checkov-action@master
+    #   with:
+    #     directory: .
+    #     quiet: true
+    #     output_format: github_failed_only
+    #     download_external_modules: true
+    #     soft_fail: true
 
-  build_test_image:
-    needs: [linting, unit-and-integration-tests]
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    outputs:
-      image_artifact_name: ${{ steps.get_image_artifact_name.outputs.image_artifact_name }}
-      image_name: ${{ steps.get_image_name.outputs.image_name }}
-
-    steps:
-      - name: Install SBoM generator
-        run: |
-          SYFT_EXPECTED_DIGEST='74a9becd5ccb4c02de99050a632e7bfc72176d5e4e844093b1e2c5bedfb45888'
-          curl -sSfL https://github.com/anchore/syft/releases/download/v0.29.0/syft_0.29.0_linux_amd64.tar.gz -o syft.tar.gz
-          SYFT_RESULT_DIGEST=$(sha256sum syft.tar.gz | cut -d' ' -f1);
-          if [[ $SYFT_RESULT_DIGEST != "${SYFT_EXPECTED_DIGEST}" ]]; then exit 1; fi
-
-          mkdir -p syft-install/
-          tar -zxf syft.tar.gz -C syft-install/
-          mv syft-install/syft /usr/local/bin/
-          rm -rf syft.tar.gz syft-install/
-      - name: Install SBom pusher
-        run: |
-          ORAS_EXPECTED_DIGEST='660a4ecd87414d1f29610b2ed4630482f1f0d104431576d37e59752c27de37ed'
-          curl -sSfL https://github.com/oras-project/oras/releases/download/v0.12.0/oras_0.12.0_linux_amd64.tar.gz -o oras.tar.gz
-          ORAS_RESULT_DIGEST=$(sha256sum oras.tar.gz | cut -d' ' -f1);
-          if [[ $ORAS_RESULT_DIGEST != "${ORAS_EXPECTED_DIGEST}" ]]; then exit 1; fi
-
-          mkdir -p oras-install/
-          tar -zxf oras.tar.gz -C oras-install/
-          mv oras-install/oras /usr/local/bin/
-          rm -rf oras.tar.gz oras-install/
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Build image artifact name
-        id: get_image_artifact_name
-        run: |
-          IMAGE_ARTIFACT_NAME=$(echo "${GITHUB_HEAD_REF}" | sed 's_/_\-_g' )
-          echo ::set-output name=image_artifact_name::"${IMAGE_ARTIFACT_NAME}"
-      - name: Build image name
-        id: get_image_name
-        run: echo ::set-output name=image_name::"ghcr.io/international-data-spaces-association/dataspace-connector"
-      - name: Build image
-        run: |
-          docker build . -t $IMAGE:ci
-        env:
-          IMAGE: ${{ steps.get_image_name.outputs.image_name }}
-          DOCKER_BUILDKIT: 1
-      - name: Generate SBoM
-        run: |
-          BOM="${ARTIFACT}-sbom.json"
-          syft "${IMAGE}:ci" -o spdx-json > "${BOM}"
-        env:
-          IMAGE: ${{ steps.get_image_name.outputs.image_name }}
-          ARTIFACT: ${{ steps.get_image_artifact_name.outputs.image_artifact_name }}
-      - name: Build tar ball
-        id: build_tar_ball
-        run: |
-          docker save --output "${ARTIFACT}.tar" "${IMAGE}:ci"
-        env:
-          IMAGE: ${{ steps.get_image_name.outputs.image_name }}
-          ARTIFACT: ${{ steps.get_image_artifact_name.outputs.image_artifact_name }}
-      - name: Push image
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ steps.get_image_artifact_name.outputs.image_artifact_name }}-image
-          path: ${{ github.workspace }}/${{ steps.get_image_artifact_name.outputs.image_artifact_name }}.tar
-          retention-days: 1
-      - name: Push SBoM
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ steps.get_image_artifact_name.outputs.image_artifact_name }}-image-sbom.json
-          path: ${{ github.workspace }}/${{ steps.get_image_artifact_name.outputs.image_artifact_name }}-sbom.json
-          retention-days: 1
-
-  image-security-scan:
-    needs: [build_test_image]
-    timeout-minutes: 10
+  static-code-analysis:
+    needs: [style, license, linting]
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
 
     steps:
-      - name: Download image
-        uses: actions/download-artifact@v2
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+       java-version: 11
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run static code analysis
+      run: mvn -B -U compile spotbugs:check --file pom.xml
+
+  unit-and-integration-tests:
+    needs: [style, license, linting]
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [11]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Unit- and Integrationtests
+      run: mvn -B -U verify --file pom.xml -Prelease
+
+  unit-and-integration-tests-cross-version:
+    needs: [style, license, linting]
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [12, 13, 14, 15, 16]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Unit- and Integrationtests
+      run: mvn -B -U verify --file pom.xml -Prelease
+
+  mutation-tests:
+    needs: unit-and-integration-tests
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+       java-version: 11
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run Mutation Tests
+      run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml
+
+  build-test-image:
+    needs: unit-and-integration-tests
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    concurrency:
+      group: e2e
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Build registry path
+        id: get_repo
+        run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
+      - name: Login to registry
+        uses: docker/login-action@v1
         with:
-          name: ${{ needs.build_test_image.outputs.image_artifact_name }}-image
-      - name: Load image into docker
-        run: docker load --input "${GITHUB_WORKSPACE}/${ARTIFACT}.tar"
+          registry: ${{ secrets.IMAGE_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        run: |
+          docker build . -t $IMAGE:ci
         env:
-          ARTIFACT: ${{ needs.build_test_image.outputs.image_artifact_name }}
+          IMAGE: ${{ steps.get_repo.outputs.IMAGE }}
+          DOCKER_BUILDKIT: 1
+      - name: Push image
+        run: docker push $IMAGE:ci
+        env:
+          IMAGE: ${{ steps.get_repo.outputs.IMAGE }}
+
+  image-security-scan:
+    needs: build-test-image
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Build registry path
+        id: get_repo
+        run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
       - name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ needs.build_test_image.outputs.image_name }}:ci'
+          image-ref: '${{ steps.get_repo.outputs.IMAGE }}:ci'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
-          vuln-type: 'os,library'
+          vuln-type: 'os, library'
           severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
-          timeout: "9m0s"
 
   e2e-test:
-    needs: [build_test_image]
+    needs: build-test-image
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    concurrency:
+      group: e2e
 
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Cache maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Setup environment
         run: |
           curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=666 sh -
@@ -271,14 +250,6 @@ jobs:
           mkdir -p ~/.kube
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
           chmod 600 ~/.kube/config
-      - name: Download image
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ needs.build_test_image.outputs.image_artifact_name }}-image
-      - name: Load image into cluster
-        run: sudo k3s ctr images import "${GITHUB_WORKSPACE}/${ARTIFACT}.tar"
-        env:
-          ARTIFACT: ${{ needs.build_test_image.outputs.image_artifact_name }}
       - name: Test environment
         run: |
           kubectl cluster-info


### PR DESCRIPTION
This PR enables the building of `amd64` as well as `arm64` containers for Linux. Which in turn means that it is easier to execute the DSC on arm64 platforms in general, such as the MacBook with M1.