### PR TITLE
feat!: JDK 17 and Temurin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
-       java-version: 11
+       java-version: 17
        cache: 'maven'
     - name: Run style checks
       run: mvn -B -U checkstyle:check --file pom.xml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
-       java-version: 11
+       java-version: 17
        cache: 'maven'
     - name: Run license checks
       run: mvn -B -U license:check --file pom.xml
@@ -82,7 +82,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
-       java-version: 11
+       java-version: 17
        cache: 'maven'
     - name: Run static code analysis
       run: mvn -B -U compile spotbugs:check --file pom.xml
@@ -102,28 +102,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
-       java-version: 11
-       cache: 'maven'
-    - name: Unit- and Integrationtests
-      run: mvn -B -U verify --file pom.xml -Prelease
-
-  unit-and-integration-tests-cross-version:
-    needs: [style, license, linting]
-    timeout-minutes: 30
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [16, 17]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
-      with:
-       distribution: 'temurin'
-       java-version: ${{ matrix.java }}
+       java-version: 17
        cache: 'maven'
     - name: Unit- and Integrationtests
       run: mvn -B -U verify --file pom.xml -Prelease
@@ -141,7 +120,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
-       java-version: 11
+       java-version: 17
        cache: 'maven'
     - name: Run Mutation Tests
       run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+       distribution: 'temurin'
        java-version: 11
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+       cache: 'maven'
     - name: Run style checks
       run: mvn -B -U checkstyle:check --file pom.xml
 
@@ -43,15 +39,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+       distribution: 'temurin'
        java-version: 11
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+       cache: 'maven'
     - name: Run license checks
       run: mvn -B -U license:check --file pom.xml
 
@@ -87,15 +79,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+       distribution: 'temurin'
        java-version: 11
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+       cache: 'maven'
     - name: Run static code analysis
       run: mvn -B -U compile spotbugs:check --file pom.xml
 
@@ -111,15 +99,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: ${{ matrix.java }}
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+       distribution: 'temurin'
+       java-version: 11
+       cache: 'maven'
     - name: Unit- and Integrationtests
       run: mvn -B -U verify --file pom.xml -Prelease
 
@@ -131,20 +115,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [12, 13, 14, 15, 16]
+        java: [12, 13, 14, 15, 16, 17]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: ${{ matrix.java }}
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+       distribution: 'temurin'
+       java-version: ${{ matrix.java }}
+       cache: 'maven'
     - name: Unit- and Integrationtests
       run: mvn -B -U verify --file pom.xml -Prelease
 
@@ -158,15 +138,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-       java-version: 11
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+       distribution: 'temurin'
+       java-version: ${{ matrix.java }}
+       cache: 'maven'
     - name: Run Mutation Tests
       run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml
 
@@ -237,12 +213,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Cache maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Setup environment
         run: |
           curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=666 sh -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
-       java-version: ${{ matrix.java }}
+       java-version: 11
        cache: 'maven'
     - name: Run Mutation Tests
       run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
@@ -60,14 +60,6 @@ jobs:
       with:
         dockerfile: Dockerfile
         config: .hadolint.yaml
-    # - name: Lint Docker and Yaml
-    #   uses: bridgecrewio/checkov-action@master
-    #   with:
-    #     directory: .
-    #     quiet: true
-    #     output_format: github_failed_only
-    #     download_external_modules: true
-    #     soft_fail: true
 
   static-code-analysis:
     needs: [style, license, linting]
@@ -78,7 +70,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
@@ -94,11 +86,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [11]
+        java: [17]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'
@@ -116,7 +108,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
        distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [12, 13, 14, 15, 16, 17]
+        java: [16, 17]
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # Dependencies
-FROM maven:3-jdk-11 AS maven
+FROM maven:3-eclipse-temurin-17 AS maven
 WORKDIR /app
 COPY pom.xml .
 RUN mvn -e -B dependency:resolve
@@ -29,10 +29,9 @@ COPY src/main/resources ./src/main/resources
 RUN mvn -e -B clean package -DskipTests -Dmaven.javadoc.skip=true
 
 # Copy the jar and build image
-FROM gcr.io/distroless/java-debian10:11
+FROM gcr.io/distroless/java-debian11:17-non-root
 COPY --from=maven /app/target/*.jar /app/app.jar
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 29292
-USER nonroot
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 		<email>info@dataspace-connector.de</email>
 
 		<!-- Build info -->
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<maven.minimum.version>3.3.9</maven.minimum.version>
 

--- a/scripts/ci/docker/Debug.dockerfile
+++ b/scripts/ci/docker/Debug.dockerfile
@@ -15,7 +15,7 @@
 #
 
 # Dependencies
-FROM maven:3-jdk-11 AS maven
+FROM maven:3-eclipse-temurin-17 AS maven
 WORKDIR /app
 COPY pom.xml .
 RUN mvn -e -B dependency:resolve
@@ -29,7 +29,7 @@ COPY src/main/resources ./src/main/resources
 RUN mvn -e -B clean package -DskipTests -Dmaven.javadoc.skip=true
 
 # Copy the jar and build image
-FROM gcr.io/distroless/java-debian10:debug
+FROM gcr.io/distroless/java-debian11:debug
 COPY --from=maven /app/target/*.jar /app/app.jar
 WORKDIR /app
 EXPOSE 8080


### PR DESCRIPTION
This PR will:
 - Bump the jdk from 11 to 17.
 - Replace adoptopenjdk with temurin.
 - Bumps setup-java to v2.

Waiting for official distroless java 17 release.

TODO:
- [ ] Reevaluate caching strategy of this branch (there have been changes on main)
- [X] Remove license check at end of unit and integration tests