### PR TITLE
feat: remove ci concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,32 +234,32 @@ jobs:
           vuln-type: 'os, library'
           severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
 
-  # e2e-test:
-  #   needs: build-test-image
-  #   timeout-minutes: 30
-  #   runs-on: ubuntu-latest
+  e2e-test:
+    needs: build-test-image
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Cache maven packages
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ~/.m2
-  #         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-  #         restore-keys: ${{ runner.os }}-m2
-  #     - name: Setup environment
-  #       run: |
-  #         curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=666 sh -
-  #         cat /etc/rancher/k3s/k3s.yaml
-  #         mkdir -p ~/.kube
-  #         cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-  #         chmod 600 ~/.kube/config
-  #     - name: Test environment
-  #       run: |
-  #         kubectl cluster-info
-  #     - name: Run scripts
-  #       run: |
-  #         ./scripts/ci/e2e/test-provider-consumer.sh
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup environment
+        run: |
+          curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=666 sh -
+          cat /etc/rancher/k3s/k3s.yaml
+          mkdir -p ~/.kube
+          cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+          chmod 600 ~/.kube/config
+      - name: Download image
+        uses: actions/download-artifact@v2
+        with:
+          name: image-${{ github.head_ref }}
+      - name: Load image into k3s
+        run: k3s ctr images import "${GITHUB_WORKSPACE}/${GITHUB_HEAD_REF}.tar"
+      - name: Test environment
+        run: |
+          kubectl cluster-info
+      - name: Run scripts
+        run: |
+          ./scripts/ci/e2e/test-provider-consumer.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,250 +13,281 @@ env:
   OWNER: ${{ secrets.REPO_USER }}
 
 jobs:
-  style:
-    timeout-minutes: 5
+  # style:
+  #   timeout-minutes: 5
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up JDK ${{ matrix.java }}
+  #     uses: actions/setup-java@v1
+  #     with:
+  #      java-version: 11
+  #   - name: Cache maven packages
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: ~/.m2
+  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+  #       restore-keys: ${{ runner.os }}-m2
+  #   - name: Run style checks
+  #     run: mvn -B -U checkstyle:check --file pom.xml
+
+  # license:
+  #   timeout-minutes: 5
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up JDK ${{ matrix.java }}
+  #     uses: actions/setup-java@v1
+  #     with:
+  #      java-version: 11
+  #   - name: Cache maven packages
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: ~/.m2
+  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+  #       restore-keys: ${{ runner.os }}-m2
+  #   - name: Run license checks
+  #     run: mvn -B -U license:check --file pom.xml
+
+  # linting:
+  #   timeout-minutes: 5
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Lint Docker
+  #     uses: hadolint/hadolint-action@v1.5.0
+  #     with:
+  #       dockerfile: Dockerfile
+  #       config: .hadolint.yaml
+  #   # - name: Lint Docker and Yaml
+  #   #   uses: bridgecrewio/checkov-action@master
+  #   #   with:
+  #   #     directory: .
+  #   #     quiet: true
+  #   #     output_format: github_failed_only
+  #   #     download_external_modules: true
+  #   #     soft_fail: true
+
+  # static-code-analysis:
+  #   needs: [style, license, linting]
+  #   timeout-minutes: 5
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up JDK ${{ matrix.java }}
+  #     uses: actions/setup-java@v1
+  #     with:
+  #      java-version: 11
+  #   - name: Cache maven packages
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: ~/.m2
+  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+  #       restore-keys: ${{ runner.os }}-m2
+  #   - name: Run static code analysis
+  #     run: mvn -B -U compile spotbugs:check --file pom.xml
+
+  # unit-and-integration-tests:
+  #   needs: [style, license, linting]
+  #   timeout-minutes: 30
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #       java: [11]
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up JDK ${{ matrix.java }}
+  #     uses: actions/setup-java@v1
+  #     with:
+  #       java-version: ${{ matrix.java }}
+  #   - name: Cache maven packages
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: ~/.m2
+  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+  #       restore-keys: ${{ runner.os }}-m2
+  #   - name: Unit- and Integrationtests
+  #     run: mvn -B -U verify --file pom.xml -Prelease
+
+  # unit-and-integration-tests-cross-version:
+  #   needs: [style, license, linting]
+  #   timeout-minutes: 30
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #       java: [12, 13, 14, 15, 16]
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up JDK ${{ matrix.java }}
+  #     uses: actions/setup-java@v1
+  #     with:
+  #       java-version: ${{ matrix.java }}
+  #   - name: Cache maven packages
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: ~/.m2
+  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+  #       restore-keys: ${{ runner.os }}-m2
+  #   - name: Unit- and Integrationtests
+  #     run: mvn -B -U verify --file pom.xml -Prelease
+
+  # mutation-tests:
+  #   needs: unit-and-integration-tests
+  #   timeout-minutes: 30
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up JDK ${{ matrix.java }}
+  #     uses: actions/setup-java@v1
+  #     with:
+  #      java-version: 11
+  #   - name: Cache maven packages
+  #     uses: actions/cache@v2
+  #     with:
+  #       path: ~/.m2
+  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+  #       restore-keys: ${{ runner.os }}-m2
+  #   - name: Run Mutation Tests
+  #     run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml
+
+  build-test-artifact:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      with:
-       java-version: 11
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Run style checks
-      run: mvn -B -U checkstyle:check --file pom.xml
-
-  license:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      with:
-       java-version: 11
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Run license checks
-      run: mvn -B -U license:check --file pom.xml
-
-  linting:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Lint Docker
-      uses: hadolint/hadolint-action@v1.5.0
-      with:
-        dockerfile: Dockerfile
-        config: .hadolint.yaml
-    # - name: Lint Docker and Yaml
-    #   uses: bridgecrewio/checkov-action@master
-    #   with:
-    #     directory: .
-    #     quiet: true
-    #     output_format: github_failed_only
-    #     download_external_modules: true
-    #     soft_fail: true
-
-  static-code-analysis:
-    needs: [style, license, linting]
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      with:
-       java-version: 11
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Run static code analysis
-      run: mvn -B -U compile spotbugs:check --file pom.xml
-
-  unit-and-integration-tests:
-    needs: [style, license, linting]
-    timeout-minutes: 30
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [11]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java }}
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Unit- and Integrationtests
-      run: mvn -B -U verify --file pom.xml -Prelease
-
-  unit-and-integration-tests-cross-version:
-    needs: [style, license, linting]
-    timeout-minutes: 30
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [12, 13, 14, 15, 16]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java }}
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Unit- and Integrationtests
-      run: mvn -B -U verify --file pom.xml -Prelease
-
-  mutation-tests:
-    needs: unit-and-integration-tests
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      with:
-       java-version: 11
-    - name: Cache maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Run Mutation Tests
-      run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml
-
-  build-test-image:
-    # needs: unit-and-integration-tests
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Build registry path
-        id: get_repo
-        run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
-      - name: Login to registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ secrets.IMAGE_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build image
+      - name: Pull last image
         run: |
-          docker build . -t $IMAGE:ci
-        env:
-          IMAGE: ${{ steps.get_repo.outputs.IMAGE }}
-          DOCKER_BUILDKIT: 1
+          docker pull "$REGISTRY/$OWNER/dataspace-connector:latest"
       - name: Build tar ball
         run: |
-          docker save --output ~/$IMAGE-ci.tar $IMAGE:ci
+          docker save --output "~/${GITHUB_SHA}.tar" "$REGISTRY/$OWNER/dataspace-connector:latest"
       - name: Push image
         uses: actions/upload-artifact@v2
         with:
           name: image-XXX
-          path: ~/$IMAGE-ci.tar
+          path: "~/${GITHUB_SHA}.tar"
           retention-days: 1
 
-  image-security-scan:
-    needs: build-test-image
-    timeout-minutes: 15
+  pull-test-artifact:
+    needs: build-test-artifact
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - name: Download image
         uses: actions/download-artifact@v2
         with:
           name: image-XXX
-          path: ~/
-      - name: Build registry path
-        id: get_repo
-        run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
-      - name: Run vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ steps.get_repo.outputs.IMAGE }}:ci'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os, library'
-          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+          path: "~/"
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: "~/"
 
-  e2e-test:
-    needs: build-test-image
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
+  # build-test-image:
+  #   # needs: unit-and-integration-tests
+  #   timeout-minutes: 15
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
 
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Cache maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Setup environment
-        run: |
-          curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=666 sh -
-          cat /etc/rancher/k3s/k3s.yaml
-          mkdir -p ~/.kube
-          cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-          chmod 600 ~/.kube/config
-      - name: Test environment
-        run: |
-          kubectl cluster-info
-      - name: Run scripts
-        run: |
-          ./scripts/ci/e2e/test-provider-consumer.sh
+  #   steps:
+  #     - name: Checkout Repo
+  #       uses: actions/checkout@v2
+  #     - name: Build registry path
+  #       id: get_repo
+  #       run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
+  #     - name: Login to registry
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: ${{ secrets.IMAGE_REGISTRY }}
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Build image
+  #       run: |
+  #         docker build . -t $IMAGE:ci
+  #       env:
+  #         IMAGE: ${{ steps.get_repo.outputs.IMAGE }}
+  #         DOCKER_BUILDKIT: 1
+  #     - name: Build tar ball
+  #       run: |
+  #         docker save --output ~/$IMAGE-ci.tar $IMAGE:ci
+  #     - name: Push image
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: image-XXX
+  #         path: ~/$IMAGE-ci.tar
+  #         retention-days: 1
+
+  # image-security-scan:
+  #   needs: build-test-image
+  #   timeout-minutes: 15
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+
+  #   steps:
+  #     - name: Download image
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: image-XXX
+  #         path: ~/
+  #     - name: Build registry path
+  #       id: get_repo
+  #       run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
+  #     - name: Run vulnerability scanner
+  #       uses: aquasecurity/trivy-action@master
+  #       with:
+  #         image-ref: '${{ steps.get_repo.outputs.IMAGE }}:ci'
+  #         format: 'table'
+  #         exit-code: '1'
+  #         ignore-unfixed: true
+  #         vuln-type: 'os, library'
+  #         severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+
+  # e2e-test:
+  #   needs: build-test-image
+  #   timeout-minutes: 30
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Checkout Repo
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Cache maven packages
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ~/.m2
+  #         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+  #         restore-keys: ${{ runner.os }}-m2
+  #     - name: Setup environment
+  #       run: |
+  #         curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=666 sh -
+  #         cat /etc/rancher/k3s/k3s.yaml
+  #         mkdir -p ~/.kube
+  #         cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+  #         chmod 600 ~/.kube/config
+  #     - name: Test environment
+  #       run: |
+  #         kubectl cluster-info
+  #     - name: Run scripts
+  #       run: |
+  #         ./scripts/ci/e2e/test-provider-consumer.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,97 +170,67 @@ jobs:
   #   - name: Run Mutation Tests
   #     run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml
 
-  build-test-artifact:
+  build-test-image:
+    # needs: unit-and-integration-tests
+    timeout-minutes: 15
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
     steps:
-      - name: Pull last image
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Build registry path
+        id: get_repo
+        run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
+      - name: Login to registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.IMAGE_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
         run: |
-          docker pull "$REGISTRY/$OWNER/dataspace-connector:latest"
+          docker build . -t $IMAGE:ci
+        env:
+          IMAGE: ${{ steps.get_repo.outputs.IMAGE }}
+          DOCKER_BUILDKIT: 1
       - name: Build tar ball
         run: |
-          docker save --output "${GITHUB_SHA}.tar" "$REGISTRY/$OWNER/dataspace-connector:latest"
-      - name: Display structure of downloaded files
-        run: ls -R
+          docker save --output "${GITHUB_SHA}.tar" $IMAGE:ci
       - name: Push image
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.sha }}
+          name: image-${{ github.sha }}
           path: ${{ github.workspace }}/${{ github.sha }}.tar
           retention-days: 1
 
-  pull-test-artifact:
-    needs: build-test-artifact
+  image-security-scan:
+    needs: build-test-image
+    timeout-minutes: 10
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
     steps:
       - name: Download image
         uses: actions/download-artifact@v2
         with:
-          name: ${{ github.sha }}
-      - name: Display structure of downloaded files
-        run: ls -R
-
-  # build-test-image:
-  #   # needs: unit-and-integration-tests
-  #   timeout-minutes: 15
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v2
-  #     - name: Build registry path
-  #       id: get_repo
-  #       run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
-  #     - name: Login to registry
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: ${{ secrets.IMAGE_REGISTRY }}
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Build image
-  #       run: |
-  #         docker build . -t $IMAGE:ci
-  #       env:
-  #         IMAGE: ${{ steps.get_repo.outputs.IMAGE }}
-  #         DOCKER_BUILDKIT: 1
-  #     - name: Build tar ball
-  #       run: |
-  #         docker save --output ~/$IMAGE-ci.tar $IMAGE:ci
-  #     - name: Push image
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: image-XXX
-  #         path: ~/$IMAGE-ci.tar
-  #         retention-days: 1
-
-  # image-security-scan:
-  #   needs: build-test-image
-  #   timeout-minutes: 15
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-
-  #   steps:
-  #     - name: Download image
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: image-XXX
-  #         path: ~/
-  #     - name: Build registry path
-  #       id: get_repo
-  #       run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
-  #     - name: Run vulnerability scanner
-  #       uses: aquasecurity/trivy-action@master
-  #       with:
-  #         image-ref: '${{ steps.get_repo.outputs.IMAGE }}:ci'
-  #         format: 'table'
-  #         exit-code: '1'
-  #         ignore-unfixed: true
-  #         vuln-type: 'os, library'
-  #         severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+          name: image-${{ github.sha }}
+      - name: Load image into docker
+        run: docker load --input "${GITHUB_WORKSPACE}/${GITHUB_SHA}.tar"
+      - name: Build registry path
+        id: get_repo
+        run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
+      - name: Run vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ steps.get_repo.outputs.IMAGE }}:ci'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os, library'
+          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
 
   # e2e-test:
   #   needs: build-test-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,11 +171,9 @@ jobs:
       run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml
 
   build-test-image:
-    needs: unit-and-integration-tests
+    # needs: unit-and-integration-tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    concurrency:
-      group: e2e
     strategy:
       fail-fast: false
 
@@ -197,10 +195,15 @@ jobs:
         env:
           IMAGE: ${{ steps.get_repo.outputs.IMAGE }}
           DOCKER_BUILDKIT: 1
+      - name: Build tar ball
+        run: |
+          docker save --output /$IMAGE:ci.tar $IMAGE:ci
       - name: Push image
-        run: docker push $IMAGE:ci
-        env:
-          IMAGE: ${{ steps.get_repo.outputs.IMAGE }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: image-XXX
+          path: /$IMAGE:ci.tar
+          retention-days: 1
 
   image-security-scan:
     needs: build-test-image
@@ -210,8 +213,11 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
+      - name: Download image
+        uses: actions/download-artifact@v2
+        with:
+          name: image-XXX
+          path: /
       - name: Build registry path
         id: get_repo
         run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"
@@ -229,8 +235,6 @@ jobs:
     needs: build-test-image
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    concurrency:
-      group: e2e
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,12 +197,12 @@ jobs:
           DOCKER_BUILDKIT: 1
       - name: Build tar ball
         run: |
-          docker save --output "${GITHUB_SHA}.tar" $IMAGE:ci
+          docker save --output "${GITHUB_HEAD_REF}.tar" "${IMAGE}:ci"
       - name: Push image
         uses: actions/upload-artifact@v2
         with:
-          name: image-${{ github.sha }}
-          path: ${{ github.workspace }}/${{ github.sha }}.tar
+          name: image-${{ github.head_ref }}
+          path: ${{ github.workspace }}/${{ github.head_ref }}.tar
           retention-days: 1
 
   image-security-scan:
@@ -216,7 +216,7 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v2
         with:
-          name: image-${{ github.sha }}
+          name: image-${{ github.head_ref }}
       - name: Load image into docker
         run: docker load --input "${GITHUB_WORKSPACE}/${GITHUB_SHA}.tar"
       - name: Build registry path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,8 @@ jobs:
       - name: Push image
         uses: actions/upload-artifact@v2
         with:
-          name: image-XXX
-          path: "./*.tar"
+          name: ${{ env.GITHUB_SHA }}
+          path: ${{ github.workspace }}/${{ env.GITHUB_SHA }}.tar
           retention-days: 1
 
   pull-test-artifact:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,165 +13,165 @@ env:
   OWNER: ${{ secrets.REPO_USER }}
 
 jobs:
-  # style:
-  #   timeout-minutes: 5
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
+  style:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up JDK ${{ matrix.java }}
-  #     uses: actions/setup-java@v1
-  #     with:
-  #      java-version: 11
-  #   - name: Cache maven packages
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: ~/.m2
-  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-  #       restore-keys: ${{ runner.os }}-m2
-  #   - name: Run style checks
-  #     run: mvn -B -U checkstyle:check --file pom.xml
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+       java-version: 11
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run style checks
+      run: mvn -B -U checkstyle:check --file pom.xml
 
-  # license:
-  #   timeout-minutes: 5
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
+  license:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up JDK ${{ matrix.java }}
-  #     uses: actions/setup-java@v1
-  #     with:
-  #      java-version: 11
-  #   - name: Cache maven packages
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: ~/.m2
-  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-  #       restore-keys: ${{ runner.os }}-m2
-  #   - name: Run license checks
-  #     run: mvn -B -U license:check --file pom.xml
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+       java-version: 11
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run license checks
+      run: mvn -B -U license:check --file pom.xml
 
-  # linting:
-  #   timeout-minutes: 5
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
+  linting:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Lint Docker
-  #     uses: hadolint/hadolint-action@v1.5.0
-  #     with:
-  #       dockerfile: Dockerfile
-  #       config: .hadolint.yaml
-  #   # - name: Lint Docker and Yaml
-  #   #   uses: bridgecrewio/checkov-action@master
-  #   #   with:
-  #   #     directory: .
-  #   #     quiet: true
-  #   #     output_format: github_failed_only
-  #   #     download_external_modules: true
-  #   #     soft_fail: true
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint Docker
+      uses: hadolint/hadolint-action@v1.5.0
+      with:
+        dockerfile: Dockerfile
+        config: .hadolint.yaml
+    # - name: Lint Docker and Yaml
+    #   uses: bridgecrewio/checkov-action@master
+    #   with:
+    #     directory: .
+    #     quiet: true
+    #     output_format: github_failed_only
+    #     download_external_modules: true
+    #     soft_fail: true
 
-  # static-code-analysis:
-  #   needs: [style, license, linting]
-  #   timeout-minutes: 5
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
+  static-code-analysis:
+    needs: [style, license, linting]
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up JDK ${{ matrix.java }}
-  #     uses: actions/setup-java@v1
-  #     with:
-  #      java-version: 11
-  #   - name: Cache maven packages
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: ~/.m2
-  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-  #       restore-keys: ${{ runner.os }}-m2
-  #   - name: Run static code analysis
-  #     run: mvn -B -U compile spotbugs:check --file pom.xml
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+       java-version: 11
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run static code analysis
+      run: mvn -B -U compile spotbugs:check --file pom.xml
 
-  # unit-and-integration-tests:
-  #   needs: [style, license, linting]
-  #   timeout-minutes: 30
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #       java: [11]
+  unit-and-integration-tests:
+    needs: [style, license, linting]
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [11]
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up JDK ${{ matrix.java }}
-  #     uses: actions/setup-java@v1
-  #     with:
-  #       java-version: ${{ matrix.java }}
-  #   - name: Cache maven packages
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: ~/.m2
-  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-  #       restore-keys: ${{ runner.os }}-m2
-  #   - name: Unit- and Integrationtests
-  #     run: mvn -B -U verify --file pom.xml -Prelease
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Unit- and Integrationtests
+      run: mvn -B -U verify --file pom.xml -Prelease
 
-  # unit-and-integration-tests-cross-version:
-  #   needs: [style, license, linting]
-  #   timeout-minutes: 30
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #       java: [12, 13, 14, 15, 16]
+  unit-and-integration-tests-cross-version:
+    needs: [style, license, linting]
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [12, 13, 14, 15, 16]
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up JDK ${{ matrix.java }}
-  #     uses: actions/setup-java@v1
-  #     with:
-  #       java-version: ${{ matrix.java }}
-  #   - name: Cache maven packages
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: ~/.m2
-  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-  #       restore-keys: ${{ runner.os }}-m2
-  #   - name: Unit- and Integrationtests
-  #     run: mvn -B -U verify --file pom.xml -Prelease
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Unit- and Integrationtests
+      run: mvn -B -U verify --file pom.xml -Prelease
 
-  # mutation-tests:
-  #   needs: unit-and-integration-tests
-  #   timeout-minutes: 30
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
+  mutation-tests:
+    needs: unit-and-integration-tests
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up JDK ${{ matrix.java }}
-  #     uses: actions/setup-java@v1
-  #     with:
-  #      java-version: 11
-  #   - name: Cache maven packages
-  #     uses: actions/cache@v2
-  #     with:
-  #       path: ~/.m2
-  #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-  #       restore-keys: ${{ runner.os }}-m2
-  #   - name: Run Mutation Tests
-  #     run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+       java-version: 11
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run Mutation Tests
+      run: mvn -B -U -Dmaven.javadoc.skip=true test org.pitest:pitest-maven:mutationCoverage --file pom.xml
 
   build-test-image:
-    # needs: unit-and-integration-tests
+    needs: unit-and-integration-tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: image-XXX
-          path: "${GITHUB_SHA}.tar"
+          path: "./${GITHUB_SHA}.tar"
           retention-days: 1
 
   pull-test-artifact:
@@ -202,7 +202,6 @@ jobs:
           name: image-XXX
       - name: Display structure of downloaded files
         run: ls -R
-        working-directory: "~/"
 
   # build-test-image:
   #   # needs: unit-and-integration-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: image-XXX
-          path: "./${GITHUB_SHA}.tar"
+          path: "./${{GITHUB_SHA}}.tar"
           retention-days: 1
 
   pull-test-artifact:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ${{ github.head_ref }}-image
-      - name: Load image into k3s
+      - name: Load image into cluster
         run: sudo k3s ctr images import "${GITHUB_WORKSPACE}/${GITHUB_HEAD_REF}.tar"
       - name: Test environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,17 +174,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
       - name: Pull last image
         run: |
           docker pull "$REGISTRY/$OWNER/dataspace-connector:latest"
       - name: Build tar ball
         run: |
-          docker save --output "~/${GITHUB_SHA}.tar" "$REGISTRY/$OWNER/dataspace-connector:latest"
+          docker save --output "${GITHUB_SHA}.tar" "$REGISTRY/$OWNER/dataspace-connector:latest"
       - name: Push image
         uses: actions/upload-artifact@v2
         with:
           name: image-XXX
-          path: "~/${GITHUB_SHA}.tar"
+          path: "./${GITHUB_SHA}.tar"
           retention-days: 1
 
   pull-test-artifact:
@@ -196,7 +198,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: image-XXX
-          path: "~/"
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: "~/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Push image
         uses: actions/upload-artifact@v2
         with:
-          name: image-${{ github.head_ref }}
+          name: ${{ github.head_ref }}-image
           path: ${{ github.workspace }}/${{ github.head_ref }}.tar
           retention-days: 1
 
@@ -218,7 +218,7 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v2
         with:
-          name: image-${{ github.head_ref }}
+          name: ${{ github.head_ref }}-image
       - name: Load image into docker
         run: docker load --input "${GITHUB_WORKSPACE}/${GITHUB_HEAD_REF}.tar"
       - name: Build registry path
@@ -254,9 +254,9 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v2
         with:
-          name: image-${{ github.head_ref }}
+          name: ${{ github.head_ref }}-image
       - name: Load image into k3s
-        run: k3s ctr images import "${GITHUB_WORKSPACE}/${GITHUB_HEAD_REF}.tar"
+        run: sudo k3s ctr images import "${GITHUB_WORKSPACE}/${GITHUB_HEAD_REF}.tar"
       - name: Test environment
         run: |
           kubectl cluster-info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,11 +182,13 @@ jobs:
       - name: Build tar ball
         run: |
           docker save --output "${GITHUB_SHA}.tar" "$REGISTRY/$OWNER/dataspace-connector:latest"
+      - name: Display structure of downloaded files
+        run: ls -R
       - name: Push image
         uses: actions/upload-artifact@v2
         with:
           name: image-XXX
-          path: "./${GITHUB_SHA}.tar"
+          path: "${GITHUB_SHA}.tar"
           retention-days: 1
 
   pull-test-artifact:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,8 +174,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
       - name: Pull last image
         run: |
           docker pull "$REGISTRY/$OWNER/dataspace-connector:latest"
@@ -187,8 +185,8 @@ jobs:
       - name: Push image
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.GITHUB_SHA }}
-          path: ${{ github.workspace }}/${{ env.GITHUB_SHA }}.tar
+          name: ${{ github.sha }}
+          path: ${{ github.workspace }}/${{ github.sha }}.tar
           retention-days: 1
 
   pull-test-artifact:
@@ -199,7 +197,7 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v2
         with:
-          name: image-XXX
+          name: ${{ github.sha }}
       - name: Display structure of downloaded files
         run: ls -R
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         with:
           name: image-${{ github.head_ref }}
       - name: Load image into docker
-        run: docker load --input "${GITHUB_WORKSPACE}/${GITHUB_SHA}.tar"
+        run: docker load --input "${GITHUB_WORKSPACE}/${GITHUB_HEAD_REF}.tar"
       - name: Build registry path
         id: get_repo
         run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,12 +197,12 @@ jobs:
           DOCKER_BUILDKIT: 1
       - name: Build tar ball
         run: |
-          docker save --output /$IMAGE:ci.tar $IMAGE:ci
+          docker save --output ~/$IMAGE-ci.tar $IMAGE:ci
       - name: Push image
         uses: actions/upload-artifact@v2
         with:
           name: image-XXX
-          path: /$IMAGE:ci.tar
+          path: ~/$IMAGE-ci.tar
           retention-days: 1
 
   image-security-scan:
@@ -217,7 +217,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: image-XXX
-          path: /
+          path: ~/
       - name: Build registry path
         id: get_repo
         run: echo ::set-output name=IMAGE::"$REGISTRY/$OWNER/dataspace-connector"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
-          vuln-type: 'os, library'
+          vuln-type: 'os,library'
           severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
 
   e2e-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: image-XXX
-          path: "./${{GITHUB_SHA}}.tar"
+          path: "./*.tar"
           retention-days: 1
 
   pull-test-artifact:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,8 @@ jobs:
       - name: Build tar ball
         run: |
           docker save --output "${GITHUB_HEAD_REF}.tar" "${IMAGE}:ci"
+        env:
+          IMAGE: ${{ steps.get_repo.outputs.IMAGE }}
       - name: Push image
         uses: actions/upload-artifact@v2
         with:

--- a/charts/dataspace-connector/Chart.yaml
+++ b/charts/dataspace-connector/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dataspace-connector/values.yaml
+++ b/charts/dataspace-connector/values.yaml
@@ -4,6 +4,8 @@ replicaCount: 1
 image:
   repository: ghcr.io/international-data-spaces-association/dataspace-connector
   pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
 
 env:
   config:

--- a/scripts/ci/libraries/dsc.sh
+++ b/scripts/ci/libraries/dsc.sh
@@ -15,43 +15,18 @@
 # limitations under the License.
 #
 
-
-function dsc::setup_build_folder() {
-    export PROVIDER_CHART=$BUILD_FOLDER/$TEST_SUITE/provider
-    export CONSUMER_CHART=$BUILD_FOLDER/$TEST_SUITE/consumer
-
-    # Provider setup
-    rm -r -f $PROVIDER_CHART
-    mkdir -p $PROVIDER_CHART
-    cp -r charts $PROVIDER_CHART
-    sed -i "s/^appVersion:.*$/appVersion: $PROVIDER_VERSION/" $PROVIDER_CHART/charts/dataspace-connector/Chart.yaml
-
-    # Consumer setup
-    rm -r -f $CONSUMER_CHART
-    mkdir -p $CONSUMER_CHART
-    cp -r charts $CONSUMER_CHART
-    sed -i "s/^appVersion:.*$/appVersion: $CONSUMER_VERSION/" $CONSUMER_CHART/charts/dataspace-connector/Chart.yaml
-}
-
-function dsc::cleanup_build_folder() {
-    rm -r -f $PROVIDER_CHART
-    rm -r -f $CONSUMER_CHART
-}
-
 function dsc::run_provider_consumer_test() {
     test::reset_test_suit
     echo "$LINE_BREAK_STAR"
-
-    dsc::setup_build_folder
 
     echo "Runnning test suite: $TEST_SUITE"
     echo "Setup provider ($PROVIDER_VERSION) and consumer ($CONSUMER_VERSION)"
 
     # Provider setup
-    helm install provider "$PROVIDER_CHART"/charts/dataspace-connector --set env.config.SPRING_APPLICATION_NAME="Provider Connector" 2>&1 > /dev/null
+    helm install provider ./charts/dataspace-connector --set image.pullPolicy=IfNotPresent --set image.tag="${PROVIDER_VERSION}" --set env.config.SPRING_APPLICATION_NAME="Provider Connector" 2>&1 > /dev/null
 
     # Consumer setup
-    helm install consumer "$CONSUMER_CHART"/charts/dataspace-connector --set env.config.SPRING_APPLICATION_NAME="Consumer Connector" 2>&1 > /dev/null
+    helm install consumer ./charts/dataspace-connector --set image.pullPolicy=IfNotPresent --set image.tag="${CONSUMER_VERSION}" --set env.config.SPRING_APPLICATION_NAME="Consumer Connector" 2>&1 > /dev/null
 
     echo "Waiting for readiness"
     kubectl rollout status deployments/provider-dataspace-connector --timeout=360s 2>&1 > /dev/null
@@ -83,6 +58,4 @@ function dsc::run_provider_consumer_test() {
     helm uninstall consumer 2>&1 > /dev/null
     # Stop port forwarding
     pkill -f "port-forward"
-
-    dsc::cleanup_build_folder
 }

--- a/scripts/ci/libraries/dsc.sh
+++ b/scripts/ci/libraries/dsc.sh
@@ -22,6 +22,8 @@ function dsc::run_provider_consumer_test() {
     echo "Runnning test suite: $TEST_SUITE"
     echo "Setup provider ($PROVIDER_VERSION) and consumer ($CONSUMER_VERSION)"
 
+    # Set the pull policy to IfNotPresent so that the postgres image is loaded but the dsc image only read from local registry
+
     # Provider setup
     helm install provider ./charts/dataspace-connector --set image.pullPolicy=IfNotPresent --set image.tag="${PROVIDER_VERSION}" --set env.config.SPRING_APPLICATION_NAME="Provider Connector" 2>&1 > /dev/null
 

--- a/scripts/ci/libraries/init.sh
+++ b/scripts/ci/libraries/init.sh
@@ -23,7 +23,6 @@ export FILE_PATH=./scripts/ci/libraries
 . "${FILE_PATH}"/libs.sh
 
 function init::setup_env_vars() {
-    export BUILD_FOLDER=build/e2e
     export TEST_SUITE=new-version
     export PROVIDER_VERSION=latest
     export CONSUMER_VERSION=latest

--- a/scripts/ci/libraries/test.sh
+++ b/scripts/ci/libraries/test.sh
@@ -21,7 +21,6 @@ function test::reset_test_suit() {
 }
 
 function test::exit() {
-    rm -r -f $BUILD_FOLDER
     if [ "$TEST_SUITE_FAILURES" -gt 0 ]; then
         exit 1
     fi


### PR DESCRIPTION
This PR will:
 - Remove need for package registry (Uses artifacts)
 - Remove concurrency problems between builds (Enables non-blocking builds)
   - Overwrite image tag in helm chart (enables loading existing images)
   - Remove build folder (no longer needed, due to tag overwrite)
- Make the pipeline more robust (fewer downloads needed)

Actions after merge:
 - Delete images with tag `ci`