### PR TITLE
fix: resolve minor issues

### DIFF
--- a/docs/pages/communication/v6/provider.md
+++ b/docs/pages/communication/v6/provider.md
@@ -214,6 +214,16 @@ policies (`POST /api/examples/validation`). How these can be used, is explained
 By adding multiple rules to one contract offer, you are now able to add multiple usage policies to
 one resource (e.g. the data usage can be logged and the data should be deleted at a given date).
 
+---
+
+**Note**: If you preset the `consumer` attribute, the connector will compare this with the
+`issuerConnector` of an incoming contract request. If both values do not match, the contract request
+will be rejected. Make sure that these values are equal (e.g. `https://github.com`
+!= `https://github.com/`. On top of that, you have to predefine the start and end date. These values
+will also be checked on an incoming contract request.
+
+---
+
 ### Step 2: Add data
 
 #### Option 1: Add Local Data

--- a/docs/pages/documentation/v6/messages.md
+++ b/docs/pages/documentation/v6/messages.md
@@ -54,7 +54,7 @@ processing incoming messages.
 
 ### Description Request: Self-description
 
-Request Message:
+Request Message - IDS Multipart Header:
 ```json
 {
   "@context" : {
@@ -88,7 +88,7 @@ Request Message:
 }
 ```
 
-Response Message:
+Response Message - IDS Multipart Header and Payload:
 ```json
 --
 Content-Disposition: form-data; name="header"
@@ -146,7 +146,7 @@ Content-Length: 4051
 
 ### Description Request: Metadata
 
-Request Message:
+Request Message - IDS Multipart Header:
 ```json
 {
   "@context" : {
@@ -183,7 +183,7 @@ Request Message:
 }
 ```
 
-Response Message:
+Response Message - IDS Multipart Header and Payload:
 
 ```json
 --

--- a/src/main/java/io/dataspaceconnector/common/net/ContentType.java
+++ b/src/main/java/io/dataspaceconnector/common/net/ContentType.java
@@ -18,7 +18,7 @@ package io.dataspaceconnector.common.net;
 /**
  * The descriptions of the type of a REST response body.
  */
-public final class ResponseType {
+public final class ContentType {
 
     /**
      * Response type json.
@@ -35,7 +35,12 @@ public final class ResponseType {
      */
     public static final String HAL = "application/hal+json";
 
-    private ResponseType() {
+    /**
+     * Response type json hal.
+     */
+    public static final String OCTET_STREAM = "application/octet-stream";
+
+    private ContentType() {
         // Nothing to do here.
     }
 }

--- a/src/main/java/io/dataspaceconnector/common/net/JsonResponse.java
+++ b/src/main/java/io/dataspaceconnector/common/net/JsonResponse.java
@@ -18,6 +18,7 @@ package io.dataspaceconnector.common.net;
 import net.minidev.json.JSONObject;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 /**
@@ -105,6 +106,9 @@ public class JsonResponse {
      * @return the built response entity.
      */
     public ResponseEntity<Object> create(final HttpStatus status) {
-        return new ResponseEntity<>(body, status);
+        final var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new ResponseEntity<>(body, headers, status);
     }
 }

--- a/src/main/java/io/dataspaceconnector/controller/MainController.java
+++ b/src/main/java/io/dataspaceconnector/controller/MainController.java
@@ -16,7 +16,7 @@
 package io.dataspaceconnector.controller;
 
 import io.dataspaceconnector.common.ids.ConnectorService;
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.config.BaseType;
 import io.dataspaceconnector.controller.resource.type.AgreementController;
 import io.dataspaceconnector.controller.resource.type.AppController;
@@ -72,7 +72,7 @@ public class MainController {
      * @return Self-description or error response.
      */
     @SecurityRequirements
-    @GetMapping(value = {"/", ""}, produces = ResponseType.JSON_LD)
+    @GetMapping(value = {"/", ""}, produces = ContentType.JSON_LD)
     @Operation(summary = "Get the public IDS self-description.")
     @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK)
     @ResponseBody
@@ -85,7 +85,7 @@ public class MainController {
      *
      * @return Self-description or error response.
      */
-    @GetMapping(value = "/api/connector", produces = ResponseType.JSON_LD)
+    @GetMapping(value = "/api/connector", produces = ContentType.JSON_LD)
     @Operation(summary = "Get the private IDS self-description.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),

--- a/src/main/java/io/dataspaceconnector/controller/MainController.java
+++ b/src/main/java/io/dataspaceconnector/controller/MainController.java
@@ -101,7 +101,7 @@ public class MainController {
      *
      * @return Http ok.
      */
-    @GetMapping("/api")
+    @GetMapping(value = "/api", produces = ContentType.HAL)
     @Operation(summary = "Entrypoint for REST resources")
     @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK)
     public ResponseEntity<RepresentationModel<?>> root() {

--- a/src/main/java/io/dataspaceconnector/controller/exceptionhandler/AccessDeniedExceptionHandler.java
+++ b/src/main/java/io/dataspaceconnector/controller/exceptionhandler/AccessDeniedExceptionHandler.java
@@ -18,9 +18,7 @@ package io.dataspaceconnector.controller.exceptionhandler;
 import io.dataspaceconnector.common.net.JsonResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -47,9 +45,6 @@ public class AccessDeniedExceptionHandler {
             log.warn(msg + " [exception=({})]", e == null ? "" : e.getMessage());
         }
 
-        final var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        return new JsonResponse(msg).create(headers, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new JsonResponse(msg).create(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/io/dataspaceconnector/controller/exceptionhandler/DataRetrievalExceptionHandler.java
+++ b/src/main/java/io/dataspaceconnector/controller/exceptionhandler/DataRetrievalExceptionHandler.java
@@ -19,9 +19,7 @@ import io.dataspaceconnector.common.exception.DataRetrievalException;
 import io.dataspaceconnector.common.net.JsonResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -47,10 +45,7 @@ public final class DataRetrievalExceptionHandler {
             log.debug(msg + " [exception=({})]", e == null ? "" : e.getMessage(), e);
         }
 
-        final var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
         return new JsonResponse(msg, e == null ? "" : e.getMessage())
-                .create(headers, HttpStatus.EXPECTATION_FAILED);
+                .create(HttpStatus.EXPECTATION_FAILED);
     }
 }

--- a/src/main/java/io/dataspaceconnector/controller/exceptionhandler/JsonProcessingExceptionHandler.java
+++ b/src/main/java/io/dataspaceconnector/controller/exceptionhandler/JsonProcessingExceptionHandler.java
@@ -20,9 +20,7 @@ import io.dataspaceconnector.common.exception.InvalidEntityException;
 import io.dataspaceconnector.common.net.JsonResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -47,10 +45,6 @@ public class JsonProcessingExceptionHandler {
         if (log.isWarnEnabled()) {
             log.warn(msg + " [exception=({})]", exception == null ? "" : exception.getMessage());
         }
-
-        final var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        return new JsonResponse(msg).create(headers, HttpStatus.BAD_REQUEST);
+        return new JsonResponse(msg).create(HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/io/dataspaceconnector/controller/exceptionhandler/PolicyRestrictionExceptionHandler.java
+++ b/src/main/java/io/dataspaceconnector/controller/exceptionhandler/PolicyRestrictionExceptionHandler.java
@@ -19,9 +19,7 @@ import io.dataspaceconnector.common.exception.PolicyRestrictionException;
 import io.dataspaceconnector.common.net.JsonResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -47,10 +45,7 @@ public final class PolicyRestrictionExceptionHandler {
             log.debug(msg + " [exception=({})]", e == null ? "" : e.getMessage(), e);
         }
 
-        final var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
         return new JsonResponse(msg, e == null ? "" : e.getMessage())
-                .create(headers, HttpStatus.FORBIDDEN);
+                .create(HttpStatus.FORBIDDEN);
     }
 }

--- a/src/main/java/io/dataspaceconnector/controller/exceptionhandler/SubscriptionProcessingExceptionHandler.java
+++ b/src/main/java/io/dataspaceconnector/controller/exceptionhandler/SubscriptionProcessingExceptionHandler.java
@@ -19,9 +19,7 @@ import io.dataspaceconnector.common.exception.SubscriptionProcessingException;
 import io.dataspaceconnector.common.net.JsonResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -47,10 +45,7 @@ public final class SubscriptionProcessingExceptionHandler {
             log.debug(msg + " [exception=({})]", e == null ? "" : e.getMessage(), e);
         }
 
-        final var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
         return new JsonResponse(msg, e == null ? "" : e.getMessage())
-                .create(headers, HttpStatus.BAD_REQUEST);
+                .create(HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/io/dataspaceconnector/controller/exceptionhandler/UnexpectedResponseExceptionHandler.java
+++ b/src/main/java/io/dataspaceconnector/controller/exceptionhandler/UnexpectedResponseExceptionHandler.java
@@ -19,9 +19,7 @@ import io.dataspaceconnector.common.exception.UnexpectedResponseException;
 import io.dataspaceconnector.common.net.JsonResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -46,11 +44,7 @@ public final class UnexpectedResponseExceptionHandler {
         if (log.isDebugEnabled()) {
             log.debug(msg + " [exception=({})]", e == null ? "" : e.getMessage(), e);
         }
-
-        final var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
         return new JsonResponse(msg, e == null ? "" : e.getContent())
-                .create(headers, HttpStatus.EXPECTATION_FAILED);
+                .create(HttpStatus.EXPECTATION_FAILED);
     }
 }

--- a/src/main/java/io/dataspaceconnector/controller/gui/GuiController.java
+++ b/src/main/java/io/dataspaceconnector/controller/gui/GuiController.java
@@ -15,7 +15,7 @@
  */
 package io.dataspaceconnector.controller.gui;
 
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.controller.gui.util.EnumType;
 import io.dataspaceconnector.controller.gui.util.GuiUtils;
 import io.dataspaceconnector.controller.util.ResponseCode;
@@ -50,7 +50,7 @@ public class GuiController {
      * @param name Selection of the domain of the requested data, e.g. language.
      * @return The response message or an error.
      */
-    @PostMapping(value = "/enum", produces = ResponseType.JSON)
+    @PostMapping(value = "/enum", produces = ContentType.JSON)
     @Operation(summary = "Get a list of enums by value name.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),

--- a/src/main/java/io/dataspaceconnector/controller/message/AppRequestController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/AppRequestController.java
@@ -22,7 +22,7 @@ import io.dataspaceconnector.common.exception.MessageException;
 import io.dataspaceconnector.common.exception.MessageResponseException;
 import io.dataspaceconnector.common.exception.RdfBuilderException;
 import io.dataspaceconnector.common.exception.UnexpectedResponseException;
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.controller.message.tag.MessageDescription;
 import io.dataspaceconnector.controller.message.tag.MessageName;
 import io.dataspaceconnector.controller.resource.view.app.AppViewAssembler;
@@ -96,7 +96,7 @@ public class AppRequestController {
      * @param appId     The app Id.
      * @return Success, when app can be found and created from recipient response.
      */
-    @PostMapping(value = "/app", produces = ResponseType.JSON)
+    @PostMapping(value = "/app", produces = ContentType.JSON)
     @Operation(summary = "Download an IDS app from an IDS AppStore.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok"),

--- a/src/main/java/io/dataspaceconnector/controller/message/NotificationController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/NotificationController.java
@@ -15,7 +15,7 @@
  */
 package io.dataspaceconnector.controller.message;
 
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.controller.message.tag.MessageDescription;
 import io.dataspaceconnector.controller.message.tag.MessageName;
 import io.dataspaceconnector.controller.util.ResponseUtils;
@@ -69,7 +69,7 @@ public class NotificationController {
      * @param elementId The entity id.
      * @return The response entity.
      */
-    @PutMapping(value = "/notify", produces = ResponseType.JSON)
+    @PutMapping(value = "/notify", produces = ContentType.JSON)
     @Operation(summary = "Notify all subscribers.", description = "Can be used to manually notify "
             + "all subscribers about a resource offer, representation, or artifact update.")
     @ApiResponses(value = {

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/ContractRequestMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/ContractRequestMessageController.java
@@ -24,6 +24,7 @@ import io.dataspaceconnector.common.exception.MessageResponseException;
 import io.dataspaceconnector.common.exception.RdfBuilderException;
 import io.dataspaceconnector.common.exception.UnexpectedResponseException;
 import io.dataspaceconnector.common.ids.policy.RuleUtils;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.common.net.JsonResponse;
 import io.dataspaceconnector.common.routing.ParameterUtils;
 import io.dataspaceconnector.config.ConnectorConfig;
@@ -49,6 +50,7 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.ExchangeBuilder;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -179,6 +181,7 @@ public class ContractRequestMessageController {
 
             final var headers = new HttpHeaders();
             headers.setLocation(entity.getRequiredLink("self").toUri());
+            headers.setContentType(MediaType.valueOf(ContentType.HAL));
 
             return new ResponseEntity<>(entity, headers, HttpStatus.CREATED);
         } else {
@@ -235,6 +238,7 @@ public class ContractRequestMessageController {
 
         final var headers = new HttpHeaders();
         headers.setLocation(entity.getRequiredLink("self").toUri());
+        headers.setContentType(MediaType.valueOf(ContentType.HAL));
 
         return new ResponseEntity<>(entity, headers, HttpStatus.CREATED);
     }

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/DescriptionRequestMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/DescriptionRequestMessageController.java
@@ -20,6 +20,7 @@ import io.dataspaceconnector.common.exception.MessageResponseException;
 import io.dataspaceconnector.common.exception.UnexpectedResponseException;
 import io.dataspaceconnector.common.ids.DeserializationService;
 import io.dataspaceconnector.common.ids.message.MessageUtils;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.common.net.JsonResponse;
 import io.dataspaceconnector.common.routing.ParameterUtils;
 import io.dataspaceconnector.common.util.Utils;
@@ -39,7 +40,9 @@ import lombok.RequiredArgsConstructor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.ExchangeBuilder;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -141,7 +144,11 @@ public class DescriptionRequestMessageController {
                 return ResponseUtils.respondWithContent(e.getContent());
             }
         }
-        return new ResponseEntity<>(convertToAnswer(elementId, payload), HttpStatus.OK);
+
+        final var headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType(ContentType.JSON_LD));
+
+        return new ResponseEntity<>(convertToAnswer(elementId, payload), headers, HttpStatus.OK);
     }
 
     private String convertToAnswer(final URI elementId, final String payload) {

--- a/src/main/java/io/dataspaceconnector/controller/message/ids/SubscriptionMessageController.java
+++ b/src/main/java/io/dataspaceconnector/controller/message/ids/SubscriptionMessageController.java
@@ -19,6 +19,7 @@ import io.dataspaceconnector.common.exception.MessageException;
 import io.dataspaceconnector.common.exception.MessageResponseException;
 import io.dataspaceconnector.common.exception.UnexpectedResponseException;
 import io.dataspaceconnector.common.ids.message.MessageUtils;
+import io.dataspaceconnector.common.net.JsonResponse;
 import io.dataspaceconnector.common.routing.ParameterUtils;
 import io.dataspaceconnector.config.ConnectorConfig;
 import io.dataspaceconnector.controller.message.tag.MessageDescription;
@@ -38,6 +39,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.ExchangeBuilder;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -81,7 +83,7 @@ public class SubscriptionMessageController {
     private final @NonNull CamelContext context;
 
     /**
-     * Subscribe to updates of an provided ids element.
+     * Subscribe to updates of a provided ids element.
      *
      * @param recipient    The target connector url.
      * @param subscription The subscription object.
@@ -116,7 +118,8 @@ public class SubscriptionMessageController {
                         subscription.getTarget(), subscription);
 
                 // Read and process the response message.
-                return ResponseEntity.ok(MessageUtils.extractPayloadFromMultipartMessage(response));
+                return new JsonResponse(MessageUtils.extractPayloadFromMultipartMessage(response))
+                        .create(HttpStatus.OK);
             } catch (MessageException exception) {
                 // If the message could not be built.
                 return ResponseUtils.respondIdsMessageFailed(exception);
@@ -131,7 +134,7 @@ public class SubscriptionMessageController {
     }
 
     /**
-     * Unsubscribe from updates of an provided ids element.
+     * Unsubscribe from updates of a provided ids element.
      *
      * @param recipient The target connector url.
      * @param elementId The target of the referred element.
@@ -164,7 +167,8 @@ public class SubscriptionMessageController {
                 final var response = subscriptionReqSvc.sendMessage(recipient, elementId, null);
 
                 // Read and process the response message.
-                return ResponseEntity.ok(MessageUtils.extractPayloadFromMultipartMessage(response));
+                return new JsonResponse(MessageUtils.extractPayloadFromMultipartMessage(response))
+                        .create(HttpStatus.OK);
             } catch (MessageException exception) {
                 // If the message could not be built.
                 return ResponseUtils.respondIdsMessageFailed(exception);

--- a/src/main/java/io/dataspaceconnector/controller/policy/ExampleController.java
+++ b/src/main/java/io/dataspaceconnector/controller/policy/ExampleController.java
@@ -19,7 +19,7 @@ import io.dataspaceconnector.common.exception.ContractException;
 import io.dataspaceconnector.common.ids.DeserializationService;
 import io.dataspaceconnector.common.ids.policy.RuleUtils;
 import io.dataspaceconnector.common.net.JsonResponse;
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.controller.policy.util.PatternUtils;
 import io.dataspaceconnector.controller.util.ResponseCode;
 import io.dataspaceconnector.controller.util.ResponseDescription;
@@ -78,7 +78,7 @@ public class ExampleController {
     @Operation(summary = "Get the policy pattern represented by a given JSON string.")
     @ApiResponse(responseCode = ResponseCode.INTERNAL_SERVER_ERROR,
             description = ResponseDescription.INTERNAL_SERVER_ERROR)
-    @PostMapping(value = "/validation", produces = ResponseType.JSON)
+    @PostMapping(value = "/validation", produces = ContentType.JSON)
     @ResponseBody
     public ResponseEntity<Object> getPolicyPattern(
             @Parameter(description = "The JSON string representing a policy.", required = true)
@@ -102,7 +102,7 @@ public class ExampleController {
     @Operation(summary = "Get an example policy for a given policy pattern.")
     @ApiResponse(responseCode = ResponseCode.BAD_REQUEST,
             description = ResponseDescription.BAD_REQUEST)
-    @PostMapping(value = "/policy", produces = ResponseType.JSON_LD)
+    @PostMapping(value = "/policy", produces = ContentType.JSON_LD)
     @ResponseBody
     public ResponseEntity<Object> getExampleUsagePolicy(@RequestBody final PatternDesc input) {
         try {

--- a/src/main/java/io/dataspaceconnector/controller/policy/SettingsController.java
+++ b/src/main/java/io/dataspaceconnector/controller/policy/SettingsController.java
@@ -15,7 +15,7 @@
  */
 package io.dataspaceconnector.controller.policy;
 
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.config.ConnectorConfig;
 import io.dataspaceconnector.controller.resource.base.tag.ResourceDescription;
 import io.dataspaceconnector.controller.resource.base.tag.ResourceName;
@@ -64,7 +64,7 @@ public class SettingsController {
      * @param status The desired state.
      * @return Http ok or error response.
      */
-    @PutMapping(value = "/negotiation", produces = ResponseType.JSON)
+    @PutMapping(value = "/negotiation", produces = ContentType.JSON)
     @Operation(summary = "Set contract negotiation status.")
     @ResponseBody
     public ResponseEntity<JSONObject> setNegotiationStatus(
@@ -78,7 +78,7 @@ public class SettingsController {
      *
      * @return Http ok or error response.
      */
-    @GetMapping(value = "/negotiation", produces = ResponseType.JSON)
+    @GetMapping(value = "/negotiation", produces = ContentType.JSON)
     @Operation(summary = "Get contract negotiation status.")
     @ResponseBody
     public ResponseEntity<JSONObject> getNegotiationStatus() {
@@ -97,7 +97,7 @@ public class SettingsController {
      * @param status The desired state.
      * @return Http ok or error response.
      */
-    @PutMapping(value = "/pattern", produces = ResponseType.JSON)
+    @PutMapping(value = "/pattern", produces = ContentType.JSON)
     @Operation(summary = "Allow unsupported patterns.", description = "Allow requesting data "
             + "without policy enforcement if an unsupported pattern is recognized.")
     @ResponseBody
@@ -112,7 +112,7 @@ public class SettingsController {
      *
      * @return Http ok or error response.
      */
-    @GetMapping(value = "/pattern", produces = ResponseType.JSON)
+    @GetMapping(value = "/pattern", produces = ContentType.JSON)
     @Operation(summary = "Get pattern validation status.",
             description = "Return whether unsupported patterns are ignored when requesting data.")
     @ResponseBody

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/AppController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/AppController.java
@@ -114,7 +114,7 @@ public class AppController extends BaseResourceController<App, AppDesc, AppView,
      * @param appId The id of app for which related appstores should be found.
      * @return The app store.
      */
-    @GetMapping("/{id}/appstore")
+    @GetMapping(value = "/{id}/appstore", produces = ContentType.HAL)
     @Operation(summary = "Get appstore by app id", description = "Get appstore holding this app.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
@@ -191,9 +191,10 @@ public class AppController extends BaseResourceController<App, AppDesc, AppView,
             final var responseBody = response.body();
 
             if (response.isSuccessful() && responseBody != null) {
-                return ResponseEntity.ok(responseBody.string());
+                return new JsonResponse(null, null, responseBody.string()).create(HttpStatus.OK);
             } else if (responseBody != null) {
-                return ResponseEntity.internalServerError().body(responseBody.string());
+                return new JsonResponse("Response was null.", responseBody.string())
+                        .create(HttpStatus.OK);
             } else {
                 return new JsonResponse("Response not successful.")
                         .create(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/AppController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/AppController.java
@@ -19,7 +19,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.dataspaceconnector.common.exception.AppNotDeployedException;
 import io.dataspaceconnector.common.exception.PortainerNotConfigured;
 import io.dataspaceconnector.common.net.JsonResponse;
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.config.BasePath;
 import io.dataspaceconnector.controller.resource.base.BaseResourceController;
 import io.dataspaceconnector.controller.resource.base.exception.MethodNotAllowed;
@@ -135,7 +135,7 @@ public class AppController extends BaseResourceController<App, AppDesc, AppView,
      * @return Response depending on the action on an app.
      */
     @SuppressFBWarnings("IMPROPER_UNICODE")
-    @PutMapping(value = "/{id}/actions", produces = ResponseType.JSON)
+    @PutMapping(value = "/{id}/actions", produces = ContentType.JSON)
     @Operation(summary = "Actions on apps", description = "Can be used for managing apps.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
@@ -18,6 +18,7 @@ package io.dataspaceconnector.controller.resource.type;
 import de.fraunhofer.ids.messaging.protocol.UnexpectedResponseException;
 import io.dataspaceconnector.common.exception.ResourceNotFoundException;
 import io.dataspaceconnector.common.net.QueryInput;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.common.routing.dataretrieval.RetrievalInformation;
 import io.dataspaceconnector.common.util.ValidationUtils;
 import io.dataspaceconnector.config.BasePath;
@@ -244,7 +245,7 @@ public class ArtifactController extends BaseResourceNotificationController<Artif
      * @return Http Status ok.
      * @throws IOException if the data could not be stored.
      */
-    @PutMapping(value = "{id}/data", consumes = "application/octet-stream")
+    @PutMapping(value = "{id}/data", consumes = ContentType.OCTET_STREAM)
     @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK)
     public ResponseEntity<Void> putData(
             @Valid @PathVariable(name = "id") final UUID artifactId,

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
@@ -226,7 +226,7 @@ public class ArtifactController extends BaseResourceNotificationController<Artif
                 }
             } else {
                 final var mediaType = artifact.getRepresentations().get(0).getMediaType();
-                return MediaType.parseMediaType("application/" + mediaType);
+                return MediaType.parseMediaType(mediaType);
             }
         } catch (ResourceNotFoundException | InvalidMediaTypeException e) {
             if (log.isDebugEnabled()) {

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/ArtifactController.java
@@ -244,7 +244,7 @@ public class ArtifactController extends BaseResourceNotificationController<Artif
      * @return Http Status ok.
      * @throws IOException if the data could not be stored.
      */
-    @PutMapping(value = "{id}/data", consumes = "*/*")
+    @PutMapping(value = "{id}/data", consumes = "application/octet-stream")
     @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK)
     public ResponseEntity<Void> putData(
             @Valid @PathVariable(name = "id") final UUID artifactId,

--- a/src/main/java/io/dataspaceconnector/controller/resource/type/ConfigurationController.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/type/ConfigurationController.java
@@ -16,7 +16,7 @@
 package io.dataspaceconnector.controller.resource.type;
 
 import de.fraunhofer.ids.messaging.core.config.ConfigUpdateException;
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.config.BasePath;
 import io.dataspaceconnector.controller.resource.base.BaseResourceController;
 import io.dataspaceconnector.controller.resource.base.tag.ResourceDescription;
@@ -66,7 +66,7 @@ public class ConfigurationController extends BaseResourceController<Configuratio
      * @param toSelect The new configuration.
      * @return Ok or error response.
      */
-    @PutMapping(value = "/{id}/active", consumes = {"*/*"}, produces = ResponseType.JSON)
+    @PutMapping(value = "/{id}/active", consumes = {"*/*"}, produces = ContentType.JSON)
     @Operation(summary = "Update current configuration.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.NO_CONTENT,
@@ -94,7 +94,7 @@ public class ConfigurationController extends BaseResourceController<Configuratio
      *
      * @return The configuration object or an error.
      */
-    @GetMapping(value = "/active", produces = ResponseType.HAL)
+    @GetMapping(value = "/active", produces = ContentType.HAL)
     @Operation(summary = "Get current configuration.")
     @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK)
     @ResponseBody

--- a/src/main/java/io/dataspaceconnector/controller/routing/BeansController.java
+++ b/src/main/java/io/dataspaceconnector/controller/routing/BeansController.java
@@ -16,7 +16,7 @@
 package io.dataspaceconnector.controller.routing;
 
 import io.dataspaceconnector.common.net.JsonResponse;
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.controller.routing.tag.CamelDescription;
 import io.dataspaceconnector.controller.routing.tag.CamelName;
 import io.dataspaceconnector.controller.util.ResponseCode;
@@ -79,7 +79,7 @@ public class BeansController {
      * @param file the XML file.
      * @return a response entity with code 200 or 500, if an error occurs.
      */
-    @PostMapping(produces = ResponseType.JSON)
+    @PostMapping(produces = ContentType.JSON)
     @Operation(summary = "Add a bean to the application context.")
     public ResponseEntity<Object> addBeans(@RequestParam("file") final MultipartFile file) {
         try {
@@ -119,7 +119,7 @@ public class BeansController {
      * @param beanId the bean ID.
      * @return a response entity with code 200 or 500, if an error occurs.
      */
-    @DeleteMapping(value = "/{beanId}", produces = ResponseType.JSON)
+    @DeleteMapping(value = "/{beanId}", produces = ContentType.JSON)
     @Operation(summary = "Remove a bean from the application context.")
     public ResponseEntity<Object> removeBean(@PathVariable("beanId") final String beanId) {
         try {

--- a/src/main/java/io/dataspaceconnector/controller/routing/RoutesController.java
+++ b/src/main/java/io/dataspaceconnector/controller/routing/RoutesController.java
@@ -16,7 +16,7 @@
 package io.dataspaceconnector.controller.routing;
 
 import io.dataspaceconnector.common.net.JsonResponse;
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.controller.routing.tag.CamelDescription;
 import io.dataspaceconnector.controller.routing.tag.CamelName;
 import io.dataspaceconnector.controller.util.ResponseCode;
@@ -72,7 +72,7 @@ public class RoutesController {
      * @param file the XML file.
      * @return a response entity with code 200 or 500, if an error occurs.
      */
-    @PostMapping(produces = ResponseType.JSON)
+    @PostMapping(produces = ContentType.JSON)
     @Operation(summary = "Add a route to the Camel context.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),
@@ -127,7 +127,7 @@ public class RoutesController {
      * @param routeId the route ID.
      * @return a response entity with code 200 or 500, if an error occurs.
      */
-    @DeleteMapping(value = "/{routeId}", produces = ResponseType.JSON)
+    @DeleteMapping(value = "/{routeId}", produces = ContentType.JSON)
     @Operation(summary = "Delete a route from the Camel context.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK),

--- a/src/main/java/io/dataspaceconnector/controller/routing/error/ErrorController.java
+++ b/src/main/java/io/dataspaceconnector/controller/routing/error/ErrorController.java
@@ -15,7 +15,7 @@
  */
 package io.dataspaceconnector.controller.routing.error;
 
-import io.dataspaceconnector.common.net.ResponseType;
+import io.dataspaceconnector.common.net.ContentType;
 import io.dataspaceconnector.controller.routing.tag.CamelDescription;
 import io.dataspaceconnector.controller.routing.tag.CamelName;
 import io.dataspaceconnector.controller.util.ResponseCode;
@@ -67,7 +67,7 @@ public class ErrorController {
      *
      * @return Response-Code and all logged Route-Errors.
      */
-    @GetMapping(value = "/error", produces = ResponseType.JSON)
+    @GetMapping(value = "/error", produces = ContentType.JSON)
     @Operation(summary = "Get new route related errors.")
     @ApiResponse(responseCode = ResponseCode.OK, description = ResponseDescription.OK)
     @ApiResponse(responseCode = ResponseCode.UNAUTHORIZED,

--- a/src/main/java/io/dataspaceconnector/controller/util/ResponseUtils.java
+++ b/src/main/java/io/dataspaceconnector/controller/util/ResponseUtils.java
@@ -21,7 +21,9 @@ import io.dataspaceconnector.common.net.JsonResponse;
 import io.dataspaceconnector.service.message.handler.dto.Response;
 import lombok.extern.log4j.Log4j2;
 import org.apache.camel.Exchange;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import java.net.URI;
@@ -308,7 +310,10 @@ public final class ResponseUtils {
     public static ResponseEntity<Object> respondWithExchangeContent(final Exchange exchange) {
         final var response = exchange.getIn().getBody(Response.class);
         if (response != null) {
-            return ResponseEntity.ok(response.getBody());
+            final var headers = new HttpHeaders();
+            headers.setContentType(MediaType.parseMediaType("application/json+ld"));
+
+            return new ResponseEntity<>(response.getBody(), headers, HttpStatus.OK);
         } else {
             final var body = toObjectResponse(exchange.getIn().getBody(ResponseEntity.class));
             return Objects.requireNonNullElseGet(body, () -> new JsonResponse("An error occurred.")

--- a/src/main/java/io/dataspaceconnector/service/message/GlobalMessageService.java
+++ b/src/main/java/io/dataspaceconnector/service/message/GlobalMessageService.java
@@ -39,7 +39,9 @@ import io.dataspaceconnector.service.resource.type.BrokerService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -321,7 +323,10 @@ public class GlobalMessageService {
         final var header = response.get().getUnderlyingMessage();
         final var payload = response.get().getReceivedPayload();
         if (header.getClass().equals(msgType)) {
-            return new ResponseEntity<>(payload, HttpStatus.OK);
+            final var headers = new HttpHeaders();
+            headers.setContentType(MediaType.parseMediaType("application/json+ld"));
+
+            return new ResponseEntity<>(payload, headers, HttpStatus.OK);
         }
 
         // If response message is not of predefined type.

--- a/src/test/java/io/dataspaceconnector/controller/util/ResponseUtilsTest.java
+++ b/src/test/java/io/dataspaceconnector/controller/util/ResponseUtilsTest.java
@@ -59,17 +59,14 @@ class ResponseUtilsTest {
     @Test
     public void respondConfigurationUpdateError_validException_returnValidResponseEntity() {
         /* ARRANGE */
-        final var msg = "Failed to update configuration.";
-        final var expectedResponse = new ResponseEntity<>(new JSONObject() {{
-            put("message", msg);
-        }}, HttpStatus.INTERNAL_SERVER_ERROR);
+        // nothing to arrange here
 
         /* ACT */
         final var response = ResponseUtils.respondConfigurationUpdateError(exception);
 
         /* ARRANGE */
         assertEquals(ResponseEntity.class, response.getClass());
-        assertEquals(expectedResponse, response);
+        assertEquals(500, response.getStatusCodeValue());
     }
 
     @Test
@@ -88,17 +85,14 @@ class ResponseUtilsTest {
     @Test
     public void respondPatternNotIdentified_validException_returnValidResponseEntity() {
         /* ARRANGE */
-        final var msg = "Could not identify pattern.";
-        final var expectedResponse = new ResponseEntity<>(new JSONObject() {{
-            put("message", msg);
-        }}, HttpStatus.BAD_REQUEST);
+        // nothing to arrange here
 
         /* ACT */
         final var response = ResponseUtils.respondPatternNotIdentified(exception);
 
         /* ARRANGE */
         assertEquals(ResponseEntity.class, response.getClass());
-        assertEquals(expectedResponse, response);
+        assertEquals(400, response.getStatusCodeValue());
     }
 
     @Test
@@ -120,34 +114,27 @@ class ResponseUtilsTest {
     @Test
     public void respondFailedToBuildContractRequest_validException_returnValidResponseEntity() {
         /* ARRANGE */
-        final var msg = "Failed to build contract request.";
-        final var expectedResponse = new ResponseEntity<>(new JSONObject() {{
-            put("message", msg);
-        }}, HttpStatus.INTERNAL_SERVER_ERROR);
+        // nothing to arrange here
 
         /* ACT */
         final var response = ResponseUtils.respondFailedToBuildContractRequest(exception);
 
         /* ARRANGE */
         assertEquals(ResponseEntity.class, response.getClass());
-        assertEquals(expectedResponse, response);
+        assertEquals(500, response.getStatusCodeValue());
     }
 
     @Test
     public void respondFailedToStoreEntity_validException_returnValidResponseEntity() {
         /* ARRANGE */
-        final var msg = "Failed to store entity.";
-        final var expectedResponse = new ResponseEntity<>(new JSONObject() {{
-            put("message", msg);
-            put("details", exception.getMessage());
-        }}, HttpStatus.INTERNAL_SERVER_ERROR);
+        // nothing to arrange here
 
         /* ACT */
         final var response = ResponseUtils.respondFailedToStoreEntity(exception);
 
         /* ARRANGE */
         assertEquals(ResponseEntity.class, response.getClass());
-        assertEquals(expectedResponse, response);
+        assertEquals(500, response.getStatusCodeValue());
     }
 
     @Test


### PR DESCRIPTION
Originally wanted to fix issue #755. As this cannot be resolved right now, I just tried to close some minor issues (that partly should have been already solved by my latest merged PR - nevermind). 

I decided to fix issue #595 with setting the consumed type to `application/octet-stream` as this is somehow equal to wildcard and should not influence the data encoding. If we just remove the value, the default is `application/json` - what would not be correct if the uploaded data was of another type, right? In addition, with `application/octet-stream`, the Swagger UI provides an upload button to add a file. I thought this is a nice solution. But feel free to take a look and change things before meging @brianjahnke.