### PR TITLE
fix: display all datasources in one array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Update IDS messaging services version from 6.0.1 to 6.1.0.
 
+### Fixed
+- Add relation annotation to `DatabaseDataSourceView` to display all `DataSources` in the same array.
+
 ## [7.0.2] - 2022-02-16
 
 ### Added

--- a/src/main/java/io/dataspaceconnector/controller/resource/view/datasource/DatabaseDataSourceView.java
+++ b/src/main/java/io/dataspaceconnector/controller/resource/view/datasource/DatabaseDataSourceView.java
@@ -15,9 +15,11 @@
  */
 package io.dataspaceconnector.controller.resource.view.datasource;
 
+import io.dataspaceconnector.config.BaseType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.hateoas.server.core.Relation;
 
 /**
  * A DTO for controlled exposing of database data source information in API responses.
@@ -25,6 +27,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = true)
+@Relation(collectionRelation = BaseType.DATA_SOURCES, itemRelation = "datasource")
 public class DatabaseDataSourceView extends DataSourceView {
 
     /**


### PR DESCRIPTION
Due to the missing `@Relation` annotation on the `DatabaseDataSourceView`, DataSources of different types are displayed in two different arrays, when the getAll() API endpoint is called. Fixed in this PR.